### PR TITLE
API Docs: Add banner that it's Alpha

### DIFF
--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -77,8 +77,8 @@ html_title = 'Inrupt {0} Documentation'.format(name)
 
 html_theme_options = {
     'project_title': 'Inrupt {0} API Documentation'.format(name),
-    'banner': False,
-    'banner_msg': '',
+    'banner': True,
+    'banner_msg': 'This is an Alpha release of the API.',
     'robots_index': True,
     'github_editable': False,
     'github_org': 'inrupt',


### PR DESCRIPTION
Wasn't sure if we wanted to put the alpha banner.  So, put up a PR to do so.  We can reject if we don't want the banner.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

