### PR TITLE
Remove dependabot from CD runs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
     - name: Create GitHub Deployment
       id: create-deployment
+      if: github.actor != 'dependabot[bot]'
       uses: octokit/request-action@v2.x
       with:
         route: POST /repos/:repository/deployments
@@ -50,6 +51,7 @@ jobs:
     - name: Mark GitHub Deployment as in progress
       id: start-deployment
       uses: octokit/request-action@v2.x
+      if: github.actor != 'dependabot[bot]'
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses
         repository: ${{ github.repository }}
@@ -67,6 +69,7 @@ jobs:
         registry-url: 'https://registry.npmjs.org'
     - name: Prepare prerelease version
       id: determine-npm-version
+      if: github.actor != 'dependabot[bot]'
       run: |
         git config user.name $GITHUB_ACTOR
         git config user.email gh-actions-${GITHUB_ACTOR}@github.com
@@ -81,6 +84,7 @@ jobs:
         TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
     - run: npm ci
     - name: Publish an npm tag for this branch
+      if: github.actor != 'dependabot[bot]'
       run: |
         # Unfortunately GitHub Actions does not currently let us do something like
         #     if: secrets.NPM_TOKEN != ''
@@ -94,6 +98,7 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
     - name: Mark GitHub Deployment as successful
+      if: github.actor != 'dependabot[bot]'
       uses: octokit/request-action@v2.x
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses
@@ -122,6 +127,7 @@ jobs:
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     - name: Waiting for npm CDNs to update...
+      if: github.actor != 'dependabot[bot]'
       run: |
         echo "Giving npm some time to make the newly-published package available…"
         sleep 5m
@@ -140,16 +146,19 @@ jobs:
         node-version: ${{ matrix.node-version }}
         registry-url: 'https://registry.npmjs.org'
     - name: Install the preview release of solid-client-notifications in the packaging test project
+      if: github.actor != 'dependabot[bot]'
       run: |
         cd .github/workflows/cd-packaging-tests/node
         npm install @inrupt/solid-client-notifications@$VERSION_NR
       env:
         VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
     - name: Verify that the package can be imported in Node from a CommonJS module
+      if: github.actor != 'dependabot[bot]'
       run: |
         cd .github/workflows/cd-packaging-tests/node
         node --unhandled-rejections=strict commonjs.cjs
     - name: Verify that the package can be imported in Node from an ES module
+      if: github.actor != 'dependabot[bot]'
       run: |
         cd .github/workflows/cd-packaging-tests/node
         node --unhandled-rejections=strict esmodule.mjs
@@ -166,6 +175,7 @@ jobs:
         node-version: '14.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Verify that the package can be imported in a Parcel project
+      if: github.actor != 'dependabot[bot]'
       run: |
         cd .github/workflows/cd-packaging-tests/bundler-parcel
         npm install
@@ -175,6 +185,7 @@ jobs:
       env:
         VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
     - name: Archive Parcel build artifacts
+      if: github.actor != 'dependabot[bot]'
       uses: actions/upload-artifact@v2.2.3
       continue-on-error: true
       with:
@@ -191,6 +202,7 @@ jobs:
         node-version: '14.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Verify that the package can be imported in a Webpack project
+      if: github.actor != 'dependabot[bot]'
       run: |
         cd .github/workflows/cd-packaging-tests/bundler-webpack
         npm install @inrupt/solid-client-notifications@$VERSION_NR
@@ -201,6 +213,7 @@ jobs:
     - name: Archive Webpack build artifacts
       uses: actions/upload-artifact@v2.2.3
       continue-on-error: true
+      if: github.actor != 'dependabot[bot]'
       with:
         name: webpack-dist
         path: .github/workflows/cd-packaging-tests/bundler-webpack/dist


### PR DESCRIPTION
Remove dependabot from CD runs, as it cannot access GitHub and NPM tokens.