### PR TITLE
Deprecate node 10, add node 16 to tests

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -6,13 +6,13 @@ env:
   CI: true
 jobs:
   unpublish-npm:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event.ref_type == 'branch'
     steps:
     - name: Prepare for unpublication from npm
       uses: actions/setup-node@v2.1.5
       with:
-        node-version: '12.x'
+        node-version: '14.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Determine npm tag
       # Remove non-alphanumeric characters

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,7 +65,7 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     - uses: actions/setup-node@v2.1.5
       with:
-        node-version: '12.x'
+        node-version: '14.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Prepare prerelease version
       id: determine-npm-version
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [14.x, 12.x]
+        node-version: [16.x, 14.x, 12.x]
     needs: [prepare-deployment, publish-npm]
     steps:
     - uses: actions/checkout@v2.3.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
         os: [ubuntu-20.04, windows-2019, macos-10.15]
-        node-version: [14.x, 12.x, 10.x]
+        node-version: [16.x, 14.x, 12.x]
     steps:
     - uses: actions/checkout@v2.3.4
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Prepare for publication to npm
       uses: actions/setup-node@v2.1.5
       with:
-        node-version: '12.x'
+        node-version: '14.x'
         registry-url: 'https://registry.npmjs.org'
     - run: npm ci
     - name: Publish to npm
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [14.x, 12.x, 10.x]
+        node-version: [16.x, 14.x, 12.x]
     needs: [prepare-deployment, publish-npm]
     steps:
     - uses: actions/checkout@v2.3.4
@@ -120,8 +120,6 @@ jobs:
       run: |
         cd .github/workflows/cd-packaging-tests/node
         node --unhandled-rejections=strict esmodule.mjs
-      # Node 10 does not support ES modules:
-      if: matrix.node-version != '10.x'
 
   verify-imports-parcel:
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ like [Babel](https://babeljs.io), and to add polyfills for e.g. `Map`, `Set`,
 `Promise`, `Headers`, `Array.prototype.includes`, `Object.entries` and
 `String.prototype.endsWith`.
 
+# Node support
+
+Our JavaScript Client Libraries track Node.js LTS releases, and support 12.x,
+14.x, and 16.x.
+
 # Installation
 
 For the latest stable version of solid-client-notifications:


### PR DESCRIPTION
* Use a consistent Ubuntu version (20.04) across all tests
* Use a consistent Node version (14.x) across test setup
* Remove Node 10.x references
* Add Node 16.x to matrix tests
* Add notice to README about Node version support