### PR TITLE
docs: replace submodule w. clone in makefile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "docs/api/docs-assets"]
-	path = docs/api/docs-assets
-	url = https://github.com/inrupt/docs-assets.git
-	branch = main

--- a/docs/api/Makefile
+++ b/docs/api/Makefile
@@ -22,16 +22,16 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCECOPYDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 
-.PHONY: help clean Makefile migrate html  submodules
-
-submodules:
-	git submodule init
-	git submodule update --remote
+.PHONY: help clean Makefile migrate html
 
 clean:
 	if [ -d $(BUILDDIR) ]; then rm -rf $(BUILDDIR) ; fi;
+	if [ -d build/docs-assets ]; then rm -rf build/docs-assets ; fi;
+
 migrate: clean
 	mkdir -p $(SOURCECOPYDIR)
+
+	git clone https://github.com/inrupt/docs-assets.git build/docs-assets
 
    # Copying to SOURCECOPYDIR instead of copying source dir to BUILDDIR
    # in case someone forgets to backslash after build/
@@ -43,7 +43,7 @@ migrate: clean
 	cp -R $(SOURCEDIR)/api/modules/ $(SOURCECOPYDIR)/modules/
 	cp -R $(SOURCEDIR)/api/classes/ $(SOURCECOPYDIR)/classes/
 	
-html: Makefile migrate submodules
+html: Makefile migrate
 
 # To clean up cross-reference links in markdown (foo.md#somesection) 
 # If making html (e.g. foo.html), use sed to change .md# to .html#
@@ -58,10 +58,6 @@ endif
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile migrate submodules
+%: Makefile migrate
 	@$(SPHINXBUILD) -M $@ "$(SOURCECOPYDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -c .
-
-
-
-	
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -42,5 +42,5 @@ When finished, can deactivate your virtual env.
 ## Third Party Licenses
 
 The `requirements.txt` lists the 3rd party libraries used for the docs.
-For the licenses, see the submodule
+For the licenses, see the shared
 [inrupt/docs-assets](https://github.com/inrupt/docs-assets#readme).

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -52,7 +52,7 @@ extensions = [
 
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['./docs-assets/_templates']
+templates_path = ['./build/docs-assets/_templates']
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -67,7 +67,7 @@ exclude_patterns = [ ]
 #html_theme = 'alabaster'
 
 html_theme = 'inrupt'
-html_theme_path = ['./docs-assets/themes']
+html_theme_path = ['./build/docs-assets/themes']
 
 html_copy_source = False
 
@@ -120,7 +120,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['./docs-assets/_static']
+html_static_path = ['./build/docs-assets/_static']
 
 html_sidebars = {
     '**': [  'search-field.html',  'docs-sidebar.html'],


### PR DESCRIPTION
Replacing the docs submodule with a git clone in Makefile. This way, it's consistent with how we're doing it now in other repos.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

