### PR TITLE
Setup end-to-end tests against dev-next

### DIFF
--- a/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
+++ b/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
@@ -7,7 +7,7 @@ export function getHelpers(podRoot: string, session: Session) {
   async function connectWebsocket(gateway: string = DEFAULT_GATEWAY) {
     const notification = new WebsocketNotification(podRoot, {
       fetch: session.fetch,
-      gateway: DEFAULT_GATEWAY,
+      gateway,
     });
 
     notification.connect();

--- a/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
+++ b/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
@@ -1,13 +1,13 @@
 import { Session } from "@inrupt/solid-client-authn-browser";
 import { WebsocketNotification } from "@inrupt/solid-client-notifications";
 
-const gateway = "https://notification.pod.inrupt.com/";
+const DEFAULT_GATEWAY = "https://notification.pod.inrupt.com/";
 
 export function getHelpers(podRoot: string, session: Session) {
-  async function connectWebsocket() {
+  async function connectWebsocket(gateway: string = DEFAULT_GATEWAY) {
     const notification = new WebsocketNotification(podRoot, {
       fetch: session.fetch,
-      gateway,
+      gateway: DEFAULT_GATEWAY,
     });
 
     notification.connect();

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -217,3 +217,47 @@ jobs:
       with:
         name: webpack-dist
         path: .github/workflows/cd-packaging-tests/bundler-webpack/dist
+
+    # Run our Node-based end-to-end tests against the published package at least once,
+  # to detect issues introduced by the build process:
+  cd-end-to-end-tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [14.x]
+    needs: [prepare-deployment, publish-npm]
+    # Dependabot does not have access to our secrets,
+    # so publishing packages for Dependabot PRs can only be manually started.
+    # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+    if: github.actor != 'dependabot[bot]'
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: actions/setup-node@v2.4.1
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm ci
+    - name: Install the preview release of solid-client
+      # The `--force` allows us to install it even though our own package has the same name.
+      # See https://docs.npmjs.com/cli/v6/commands/npm-install#limitations-of-npms-install-algorithm
+      run: |
+        npm install --force @inrupt/solid-client@$VERSION_NR
+      env:
+        VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
+    - name: Make sure that the end-to-end tests run against the just-published package
+      run: |
+        cd src/e2e-node
+        # For all files (`-type f`) in this directory,
+        # replace `../index` (i.e. in the import statement) with `@inrupt/solid-client`:
+        find ./ -type f -exec sed --in-place --expression='s/\.\.\/index/@inrupt\/solid-client/g' {} \;
+    - name: Run the Node-based end-to-end tests
+      run: npm run e2e-test-node
+      env:
+        E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
+        E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
+        E2E_TEST_ESS_CLIENT_ID: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_ID }}
+        E2E_TEST_ESS_CLIENT_SECRET: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_SECRET }}
+        E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
+        E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
+        E2E_TEST_DEV_NEXT_CLIENT_ID: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_ID }}
+        E2E_TEST_DEV_NEXT_CLIENT_SECRET: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,123 @@ jobs:
         E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
         E2E_TEST_DEV_NEXT_CLIENT_ID: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_ID }}
         E2E_TEST_DEV_NEXT_CLIENT_SECRET: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_SECRET }}
+    - name: Prepare browser-based end-to-end tests
+      run: |
+        cd .codesandbox/sandbox
+        npm install
+        # Run the end-to-end tests against the code in this branch specifically:
+        npm install ../../
+        cd ../..
+      if: matrix.node-version == env.DEFAULT_NODE_VERSION && github.actor != 'dependabot[bot]'
+    - name: Run browser-based end-to-end tests (Linux)
+      # TODO: These tests started consistently failing on 2021-08-04.
+      #       Possibly related to the new Release Candidate of Parcel 2, although
+      #       a downgrade did not fix it.
+      #       This CI run succeeded on 2021-08-03, but failed when retrying a
+      #       day later: https://github.com/inrupt/solid-client-js/actions/runs/1094162699
+      #       This is the first CI run that started failing (not terminating):
+      #       https://github.com/inrupt/solid-client-js/runs/3238702146?check_suite_focus=true
+      timeout-minutes: 5
+      continue-on-error: true
+      # TODO: Add Edge/merge with Windows setup once Edge is available on Linux:
+      # Connections are flakier in CI, so retry failed network requests with --retry-test-pages.
+      # That also requires adding `--hostname localhost` to run over HTTPS:
+      # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
+      # Setting a test-specific user agent is only possible for Chrome: https://stackoverflow.com/a/59358925
+      run: npm run e2e-test-browser -- "firefox:headless,chrome:headless:userAgent='Browser-based solid-client-notifications end-to-end tests running in CI. Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) $(chrome --version) Safari/537.36'" --screenshots takeOnFails=true,path=./e2e-browser-failures --retry-test-pages --hostname localhost
+      # The Node version does not influence how well our tests run in the browser,
+      # so we only need to test in one.
+      # Additionally, Dependabot does not have access to our secrets,
+      # so end-to-end tests for Dependabot PRs can only be manually started.
+      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+      if: matrix.node-version == env.DEFAULT_NODE_VERSION && runner.os == 'Linux' && github.event_name != 'schedule' && github.actor != 'dependabot[bot]'
+      env:
+        E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
+        E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
+        E2E_TEST_ESS_COGNITO_USER: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_USER }}
+        E2E_TEST_ESS_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_PASSWORD }}
+        E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
+        E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
+        E2E_TEST_DEV_NEXT_COGNITO_USER: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_USER }}
+        E2E_TEST_DEV_NEXT_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_PASSWORD }}
+    - name: Run browser-based end-to-end tests (Windows)
+      # TODO: These tests started consistently failing on 2021-08-04.
+      #       Possibly related to the new Release Candidate of Parcel 2, although
+      #       a downgrade did not fix it.
+      #       This CI run succeeded on 2021-08-03, but failed when retrying a
+      #       day later: https://github.com/inrupt/solid-client-js/actions/runs/1094162699
+      #       This is the first CI run that started failing (not terminating):
+      #       https://github.com/inrupt/solid-client-js/runs/3238702146?check_suite_focus=true
+      #       Note that continue-on-error was still set to true for Windows
+      #       before that, because tests running there were pretty flaky in the
+      #       first place — they job had to be manually inspected when code with
+      #       a high risk of breaking in the browser was added.
+      timeout-minutes: 5
+      continue-on-error: true
+      # Connections are flakier in CI, so retry failed network requests with --retry-test-pages.
+      # That also requires adding `--hostname localhost` to run over HTTPS:
+      # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
+      run: npm run e2e-test-browser -- edge:headless,firefox:headless,chrome:headless --retry-test-pages --hostname localhost
+      # The Node version does not influence how well our tests run in the browser,
+      # so we only need to test in one.
+      # Additionally, Dependabot does not have access to our secrets,
+      # so end-to-end tests for Dependabot PRs can only be manually started.
+      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+      if: matrix.node-version == env.DEFAULT_NODE_VERSION && runner.os == 'Windows' && github.event_name != 'schedule' && github.actor != 'dependabot[bot]'
+      env:
+        E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
+        E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
+        E2E_TEST_ESS_COGNITO_USER: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_USER }}
+        E2E_TEST_ESS_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_PASSWORD }}
+        E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
+        E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
+        E2E_TEST_DEV_NEXT_COGNITO_USER: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_USER }}
+        E2E_TEST_DEV_NEXT_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_PASSWORD }}
+    - name: Run browser-based end-to-end tests (MacOS)
+      # TODO: continue-on-error was set to true because browser-based end-to-end
+      #       tests on MacOS are pretty flaky, so this job had to be manually
+      #       inspected when code with a high risk of breaking in the browser
+      #       was added. However, with the tests on Linux currently consistently
+      #       failing, we're only relying on the MacOS tests again for now.
+      # continue-on-error: true
+      # MacOS needs a somewhat particular setup. It is running with "System Integrity Protection"
+      # enabled, which results in TestCafe needing screen recording permission, which it cannot
+      # obtain programmatically. Thus, we have to run the browser as a remote as a workaround.
+      # Source: https://devexpress.github.io/testcafe/documentation/guides/continuous-integration/github-actions.html#step-2---create-a-job
+      # Additionally, the tests on MacOS fail particularly often due to network errors;
+      # hence, they are run in quarantine mode (--quarantine-mode) to make TestCafe automatically retry them,
+      # and with --retry-test-pages to retry failed network connections.
+      # That also requires adding `--hostname localhost` to run over HTTPS:
+      # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
+      run: |
+        export HOSTNAME=localhost
+        export PORT1=1337
+        export PORT2=1338
+        npm run e2e-test-browser -- remote --hostname ${HOSTNAME} --ports ${PORT1},${PORT2} --quarantine-mode --retry-test-pages --hostname localhost &
+        pid=$!
+        sleep 1s
+        open -a Safari http://${HOSTNAME}:${PORT1}/browser/connect
+        wait $pid
+      # Connecting to a remote appears to run into a race condition every now and then,
+      # where TestCafe waits for the browser endlessly. 20 minutes should be more than enough at the
+      # time of writing for the end-to-end tests to succeed, so cut them off after that:
+      timeout-minutes: 20
+      # The Node version does not influence how well our tests run in the browser,
+      # so we only need to test in one.
+      # Additionally, Dependabot does not have access to our secrets,
+      # so end-to-end tests for Dependabot PRs can only be manually started.
+      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+      if: matrix.node-version == env.DEFAULT_NODE_VERSION && runner.os == 'macOS' && github.event_name != 'schedule' && github.actor != 'dependabot[bot]'
+      env:
+        E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
+        E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
+        E2E_TEST_ESS_COGNITO_USER: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_USER }}
+        E2E_TEST_ESS_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_PASSWORD }}
+        E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
+        E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
+        E2E_TEST_DEV_NEXT_COGNITO_USER: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_USER }}
+        E2E_TEST_DEV_NEXT_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_PASSWORD }}
+        GITHUB_OS: ${{ runner.os }}
     - run: npx package-check
     - name: Archive code coverage results
       uses: actions/upload-artifact@v2.2.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,23 @@ jobs:
     - run: npm run check-licenses
     - run: npm audit --audit-level=moderate
     - run: npm test
+    - run: npm run e2e-test-node
+      # To prevent conflicts of multiple jobs trying to modify the same Resource at the same time,
+      # and because behaviour on different OS's is already tested by unit tests,
+      # end-to-end tests only need to run on one OS.
+      # Additionally, Dependabot does not have access to our secrets,
+      # so end-to-end tests should not run for Dependabot PRs.
+      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+      if: runner.os == 'Linux' && matrix.node-version == env.DEFAULT_NODE_VERSION && github.actor != 'dependabot[bot]'
+      env:
+        E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
+        E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
+        E2E_TEST_ESS_CLIENT_ID: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_ID }}
+        E2E_TEST_ESS_CLIENT_SECRET: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_SECRET }}
+        E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
+        E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
+        E2E_TEST_DEV_NEXT_CLIENT_ID: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_ID }}
+        E2E_TEST_DEV_NEXT_CLIENT_SECRET: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_SECRET }}
     - run: npx package-check
     - name: Archive code coverage results
       uses: actions/upload-artifact@v2.2.3

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -44,7 +44,7 @@ type AuthDetails = [
   Pod,
   OidcIssuer,
   ClientId,
-  ClientSecret,
+  ClientSecret
 ];
 
 // Instructions for obtaining these credentials can be found here:
@@ -53,10 +53,20 @@ const serversUnderTest: AuthDetails[] = [
   // pod.inrupt.com:
   [
     process.env.E2E_TEST_ESS_NOTIFICATION_GATEWAY!,
-    process.env.E2E_TEST_ESS_POD!,
-    process.env.E2E_TEST_ESS_IDP_URL!,
+    process.env.E2E_TEST_ESS_POD!.replace(/^https:\/\//, ""),
+    process.env.E2E_TEST_ESS_IDP_URL!.replace(/^https:\/\//, ""),
     process.env.E2E_TEST_ESS_CLIENT_ID!,
     process.env.E2E_TEST_ESS_CLIENT_SECRET!,
+  ],
+  [
+    process.env.E2E_TEST_DEV_NEXT_NOTIFICATION_GATEWAY!,
+    // Cumbersome workaround, but:
+    // Trim `https://` from the start of these URLs,
+    // so that GitHub Actions doesn't replace them with *** in the logs.
+    process.env.E2E_TEST_DEV_NEXT_POD!.replace(/^https:\/\//, ""),
+    process.env.E2E_TEST_DEV_NEXT_IDP_URL!.replace(/^https:\/\//, ""),
+    process.env.E2E_TEST_DEV_NEXT_CLIENT_ID!,
+    process.env.E2E_TEST_DEV_NEXT_CLIENT_SECRET!,
   ],
   // pod-compat.inrupt.com, temporarily disabled while WSS is in dev:
   /*
@@ -71,14 +81,17 @@ const serversUnderTest: AuthDetails[] = [
 ];
 
 describe.each(serversUnderTest)(
-  "Authenticated end-to-end tests against Pod [%s] and OIDC Issuer [%s]:",
+  "Authenticated end-to-end tests for gateway [%s] against Pod [%s] and OIDC Issuer [%s]:",
   (
     notificationGateway,
-    rootContainer,
-    oidcIssuer,
+    rootContainerDisplay,
+    oidcIssuerDisplay,
     clientId,
     clientSecret
   ) => {
+    const rootContainer = "https://" + rootContainerDisplay;
+    const oidcIssuer = "https://" + oidcIssuerDisplay;
+
     let ws: WebsocketNotification | undefined;
 
     afterEach(() => {


### PR DESCRIPTION
This sets up the end-to-end test against the dev-next environment. It runs both the node tests (authenticated through client credentials) and the browser-based tests (authenticated with a username/password).

These tests are currently failing, and fixing them will be part of a future PR.
