### PR TITLE
Fix e2e-node workflow to exclude dependabot PRs

### DIFF
--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    if: github.actor != 'dependabot[bot]' && ${{github.event.deployment_status.state == 'success'}}
+    if: ${{github.event.deployment_status.state == 'success'}} && github.actor != 'dependabot[bot]'
     steps:
     - uses: actions/checkout@v2.3.4
     - name: Use Node.js 16.x


### PR DESCRIPTION
<!-- When fixing a bug: -->

This PR fixes the issue where node.js e2e tests where running for dependabot PRs, turns out the order in the if may be important, as the e2e browser tests were not queue for dependabot PRs.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

