### PR TITLE
Upgrade testcafe to 1.18.3 to fix nanoid security vulnerability in devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "prettier": "2.2.1",
         "rollup": "^2.60.0",
         "rollup-plugin-typescript2": "^0.30.0",
-        "testcafe": "^1.18.2",
+        "testcafe": "^1.18.3",
         "ts-jest": "^27.0.7",
         "typedoc": "^0.22.10",
         "typedoc-plugin-markdown": "^3.11.3",
@@ -8478,10 +8478,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.3.4.tgz",
-      "integrity": "sha512-4ug4BsuHxiVHoRUe1ud6rUFT3WUMmjXt1W0quL0CviZQANdan7D8kqN5/maw53hmAApY/jfzMRkC57BNNs60ZQ==",
-      "dev": true
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.0.tgz",
+      "integrity": "sha512-JzxqqT5u/x+/KOFSd7JP15DOo9nOoHpx6DYatqIHUW2+flybkm+mdcraotSQR5WcnZr+qhGVh8Ted0KdfSMxlg==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -10031,9 +10037,9 @@
       }
     },
     "node_modules/testcafe": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.18.2.tgz",
-      "integrity": "sha512-A9cPNtf4v4gacvaGX5mBmT6ctCmXmYQxYJ51TOSRfnApxVcfjuLSwZNC3p49G/6zuVhe6Xh/pwQJt7iZOdLcaQ==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.18.3.tgz",
+      "integrity": "sha512-cBWPBmY20xI9iWQzS9s2t3oIYhXl5gJzM6CTQjLXt5CMAEvWThsOzLWWnNoA2nk4CLBexZ0S5SkrYOk/SGVSaw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.1",
@@ -10061,7 +10067,7 @@
         "bowser": "^2.8.1",
         "callsite": "^1.0.0",
         "callsite-record": "^4.0.0",
-        "chai": "^4.1.2",
+        "chai": "4.3.4",
         "chalk": "^2.3.0",
         "chrome-remote-interface": "^0.30.0",
         "coffeescript": "^2.3.1",
@@ -10094,7 +10100,7 @@
         "moment": "^2.10.3",
         "moment-duration-format-commonjs": "^1.0.0",
         "mustache": "^2.1.2",
-        "nanoid": "^1.0.1",
+        "nanoid": "^3.1.31",
         "os-family": "^1.0.0",
         "parse5": "^1.5.0",
         "pify": "^2.3.0",
@@ -10111,7 +10117,7 @@
         "semver": "^5.6.0",
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
-        "testcafe-browser-tools": "2.0.21",
+        "testcafe-browser-tools": "2.0.22",
         "testcafe-hammerhead": "24.5.13",
         "testcafe-legacy-api": "5.1.2",
         "testcafe-reporter-dashboard": "0.2.5",
@@ -10134,9 +10140,9 @@
       }
     },
     "node_modules/testcafe-browser-tools": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.21.tgz",
-      "integrity": "sha512-dsaUgUY4i/VLKSexh0w8ZyvDGWd3+LfoEysN/nFCUufseiwGvvbBpsNSAV7XZN12GpExG3mCilaQDuJNBKs4CQ==",
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.22.tgz",
+      "integrity": "sha512-ABzKV3h+yrbxC0WfqqCjWP+/XFBH66VY8Nuz3IqDu4/9mbrn2sJpcEdcoxLVRVkIxcLUgCejF38Rorumh9iHvw==",
       "dev": true,
       "dependencies": {
         "array-find": "^1.0.0",
@@ -10150,7 +10156,7 @@
         "lodash": "^4.17.15",
         "mkdirp": "^0.5.1",
         "mustache": "^2.1.2",
-        "nanoid": "^2.1.3",
+        "nanoid": "^3.1.31",
         "os-family": "^1.0.0",
         "pify": "^2.3.0",
         "pinkie": "^2.0.1",
@@ -10288,12 +10294,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/testcafe-browser-tools/node_modules/nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
-      "dev": true
-    },
     "node_modules/testcafe-browser-tools/node_modules/p-map": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
@@ -10387,18 +10387,6 @@
       "dev": true,
       "dependencies": {
         "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/testcafe-hammerhead/node_modules/nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
-      "dev": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/testcafe-hammerhead/node_modules/parse5": {
@@ -17987,9 +17975,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.3.4.tgz",
-      "integrity": "sha512-4ug4BsuHxiVHoRUe1ud6rUFT3WUMmjXt1W0quL0CviZQANdan7D8kqN5/maw53hmAApY/jfzMRkC57BNNs60ZQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.0.tgz",
+      "integrity": "sha512-JzxqqT5u/x+/KOFSd7JP15DOo9nOoHpx6DYatqIHUW2+flybkm+mdcraotSQR5WcnZr+qhGVh8Ted0KdfSMxlg==",
       "dev": true
     },
     "natural-compare": {
@@ -19173,9 +19161,9 @@
       }
     },
     "testcafe": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.18.2.tgz",
-      "integrity": "sha512-A9cPNtf4v4gacvaGX5mBmT6ctCmXmYQxYJ51TOSRfnApxVcfjuLSwZNC3p49G/6zuVhe6Xh/pwQJt7iZOdLcaQ==",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.18.3.tgz",
+      "integrity": "sha512-cBWPBmY20xI9iWQzS9s2t3oIYhXl5gJzM6CTQjLXt5CMAEvWThsOzLWWnNoA2nk4CLBexZ0S5SkrYOk/SGVSaw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.1",
@@ -19203,7 +19191,7 @@
         "bowser": "^2.8.1",
         "callsite": "^1.0.0",
         "callsite-record": "^4.0.0",
-        "chai": "^4.1.2",
+        "chai": "4.3.4",
         "chalk": "^2.3.0",
         "chrome-remote-interface": "^0.30.0",
         "coffeescript": "^2.3.1",
@@ -19236,7 +19224,7 @@
         "moment": "^2.10.3",
         "moment-duration-format-commonjs": "^1.0.0",
         "mustache": "^2.1.2",
-        "nanoid": "^1.0.1",
+        "nanoid": "^3.1.31",
         "os-family": "^1.0.0",
         "parse5": "^1.5.0",
         "pify": "^2.3.0",
@@ -19253,7 +19241,7 @@
         "semver": "^5.6.0",
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
-        "testcafe-browser-tools": "2.0.21",
+        "testcafe-browser-tools": "2.0.22",
         "testcafe-hammerhead": "24.5.13",
         "testcafe-legacy-api": "5.1.2",
         "testcafe-reporter-dashboard": "0.2.5",
@@ -19460,9 +19448,9 @@
       }
     },
     "testcafe-browser-tools": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.21.tgz",
-      "integrity": "sha512-dsaUgUY4i/VLKSexh0w8ZyvDGWd3+LfoEysN/nFCUufseiwGvvbBpsNSAV7XZN12GpExG3mCilaQDuJNBKs4CQ==",
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/testcafe-browser-tools/-/testcafe-browser-tools-2.0.22.tgz",
+      "integrity": "sha512-ABzKV3h+yrbxC0WfqqCjWP+/XFBH66VY8Nuz3IqDu4/9mbrn2sJpcEdcoxLVRVkIxcLUgCejF38Rorumh9iHvw==",
       "dev": true,
       "requires": {
         "array-find": "^1.0.0",
@@ -19476,7 +19464,7 @@
         "lodash": "^4.17.15",
         "mkdirp": "^0.5.1",
         "mustache": "^2.1.2",
-        "nanoid": "^2.1.3",
+        "nanoid": "^3.1.31",
         "os-family": "^1.0.0",
         "pify": "^2.3.0",
         "pinkie": "^2.0.1",
@@ -19582,12 +19570,6 @@
             "universalify": "^2.0.0"
           }
         },
-        "nanoid": {
-          "version": "2.1.11",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-          "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
-          "dev": true
-        },
         "p-map": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
@@ -19667,12 +19649,6 @@
           "requires": {
             "readable-stream": "^2.0.1"
           }
-        },
-        "nanoid": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-          "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
-          "dev": true
         },
         "parse5": {
           "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "prettier": "2.2.1",
     "rollup": "^2.60.0",
     "rollup-plugin-typescript2": "^0.30.0",
-    "testcafe": "^1.18.2",
+    "testcafe": "^1.18.3",
     "ts-jest": "^27.0.7",
     "typedoc": "^0.22.10",
     "typedoc-plugin-markdown": "^3.11.3",


### PR DESCRIPTION
Not entirely sure why there's no dependabot alert for this, but testcafe was outdated, and that caused an audit failure in another PR, even though I'm working on migrating to playwright, this helps us in the short term.