### PR TITLE
chore: fix license header

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
-# FIXME: Remove after switching to playwright
-e2e/browser
+# e2e browser testApp has it's own separate eslint configuration:
+e2e/browser/testApp
+# ignore JS config files:
 jest.config.js
 jest.setup.js
 jest.e2e.config.js

--- a/e2e/browser/test/e2e.playwright.ts
+++ b/e2e/browser/test/e2e.playwright.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,12 +17,14 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
-/* eslint-disable jest/no-done-callback */
+/* eslint-disable jest/no-test-callback */
 
-// eslint-disable-next-line no-shadow
 import {
+  // eslint-disable-next-line no-shadow
   test,
+  // eslint-disable-next-line no-shadow
   expect,
   WebSocket as PlayWrightWebSocket,
 } from "@playwright/test";
@@ -128,7 +132,7 @@ test.skip("connecting a websocket, getting messages, and disconnecting it", asyn
     page.click("button[data-testid=createContainer]"),
   ]);
 
-  expect(framesReceived.length).toBe(1);
+  expect(framesReceived).toHaveLength(1);
   expect(framesReceived[0].type).toContain("Update");
 
   // Make sure the container can be removed.
@@ -140,7 +144,7 @@ test.skip("connecting a websocket, getting messages, and disconnecting it", asyn
     websocket.waitForEvent("framereceived"),
   ]);
 
-  expect(framesReceived.length).toBe(2);
+  expect(framesReceived).toHaveLength(2);
   expect(framesReceived[1].type).toContain("Update");
 
   await page.click("button[data-testid=disconnectSocket]");

--- a/e2e/browser/test/globalSetup.ts
+++ b/e2e/browser/test/globalSetup.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,9 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
 import { getTestingEnvironmentBrowser } from "../../e2e-setup";
 

--- a/e2e/browser/test/pageModels/broker.ts
+++ b/e2e/browser/test/pageModels/broker.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 import { Page } from "@playwright/test";
 

--- a/e2e/browser/test/pageModels/cognito.ts
+++ b/e2e/browser/test/pageModels/cognito.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 import { Page } from "@playwright/test";
 

--- a/e2e/browser/test/pageModels/index.ts
+++ b/e2e/browser/test/pageModels/index.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 import { Page } from "@playwright/test";
 import { getTestingEnvironmentBrowser } from "../../../e2e-setup";

--- a/e2e/browser/test/playwright.config.ts
+++ b/e2e/browser/test/playwright.config.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 import { PlaywrightTestConfig } from "@playwright/test";
 

--- a/e2e/browser/test/roles.ts
+++ b/e2e/browser/test/roles.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 import { Page } from "@playwright/test";
 import { IndexPage } from "./pageModels";

--- a/e2e/e2e-setup.ts
+++ b/e2e/e2e-setup.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 import { config } from "dotenv-flow";
 import { join } from "path";
 

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 import {
   // eslint-disable-next-line no-shadow

--- a/resources/license-header.js
+++ b/resources/license-header.js
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,3 +17,4 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 export class FetchError extends Error {
   response: Response;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 import {
   WebsocketNotification,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 export {
   protocols,

--- a/src/liveNotification.test.ts
+++ b/src/liveNotification.test.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 import EventEmitter from "events";
 import { LiveNotification } from "./liveNotification";

--- a/src/liveNotification.ts
+++ b/src/liveNotification.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 import { EventEmitter } from "events";
 import { NotImplementedError } from "./errors";

--- a/src/notification.test.ts
+++ b/src/notification.test.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 // Allow shadowing fetch
 /* eslint no-shadow: 0 */

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 import { fetch as crossFetch } from "cross-fetch";
 import { FetchError } from "./errors";

--- a/src/websocketNotification.test.ts
+++ b/src/websocketNotification.test.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 // Typescript and eslint are fighting over whether these are globals
 /* eslint no-shadow: 0 */

--- a/src/websocketNotification.ts
+++ b/src/websocketNotification.ts
@@ -1,4 +1,6 @@
+//
 // Copyright 2022 Inrupt Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in
 // the Software without restriction, including without limitation the rights to use,
@@ -15,6 +17,7 @@
 // HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
 
 // Typescript and eslint are fighting over whether these are globals
 /* eslint no-shadow: 0 */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -89,15 +89,5 @@
     "entryDocument": "index.md",
   },
   "include": ["src/**/*.ts", ".eslintrc.js"],
-  "exclude": [
-    "**/node_modules",
-    "tests/**/*.js",
-    // These end-to-end tests reference code in `.codesandbox`,
-    // which is not part of this project and should not be compiled together with it.
-    // Not excluding this will lead to the root of the repository being used
-    // as the root directory for compilation (instead of /src),
-    // meaning that files that would otherwise be included in /dist directly
-    // (e.g. dist/index.d.ts) will then be built to /dist/src.
-    "e2e",
-  ]
+  "exclude": ["**/node_modules", "tests/**/*.js"]
 }


### PR DESCRIPTION
The previous license header applied here is not consistent with that from ts-template, so this fixes that, whilst also ensuring the e2e tests are covered by eslint, whilst still excluding the testapp which has it's own linting configuration. 