### PR TITLE
Fix: typescript exports & minor documentation update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/.DS_Store
 .cache
 .github/workflows/cd-packaging-tests/bundler-webpack/package-lock.json
 .github/workflows/cd-packaging-tests/bundler-parcel/package-lock.json
+.vscode/settings.json

--- a/docs/api/source/index.rst
+++ b/docs/api/source/index.rst
@@ -13,7 +13,24 @@ For Solid Servers that support notifications, they are sent when a resource is
 created, updated, deleted, or when a child resource is added to or removed from
 a container.
 
-**This library currently only supports notifications sent via WebSockets.**
+.. admonition:: Supported Protocols
+   :class: caution
+
+   This library currently only supports an `early version of WebSocket
+   notifications
+   <https://docs.inrupt.com/ess/1.1/services/service-websocket/>`__, which
+   formed the basis of the Solid Notification Protocol 1.0 draft specification.
+
+   The `Solid Notification Protocol 1.0
+   <https://solid.github.io/notifications/protocol>`__ is a draft specification
+   undergoing technical review as it matures into a formal recommendation. A
+   future release will support this draft specification once implementations
+   become available. 
+   
+   **Please note:** the `legacy (insecure) WebSocket
+   <https://github.com/solid/solid-spec/blob/master/api-websockets.md>`__
+   mechanism, which is not recommended for secure messaging, is not supported by
+   this library.
 
 It is part of a `family open source JavaScript libraries
 <https://docs.inrupt.com/developer-tools/javascript/client-libraries/>`__

--- a/package.json
+++ b/package.json
@@ -37,10 +37,17 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
     },
-    "./errors": "./dist/errors.mjs",
-    "./websocketNotification": "./dist/websocketNotification.mjs"
+    "./errors": {
+      "import": "./dist/errors.mjs",
+      "types": "./dist/errors.d.ts"
+    },
+    "./websocketNotification": {
+      "import": "./dist/websocketNotification.mjs",
+      "types": "./dist/websocketNotification.d.ts"
+    }
   },
   "files": [
     "dist",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,14 +24,14 @@ import { fetch as crossFetch } from "cross-fetch";
 export type protocols = "ws" | string;
 export type statuses = "connecting" | "connected" | "closing" | "closed";
 
-/** @internal */
+/** @hidden */
 export interface NegotiationInfo {
   endpoint: string;
   procotol: protocols;
   features: FeatureOptions;
 }
 
-/** @internal */
+/** @hidden */
 export interface NotificationConnectionInfo {
   endpoint: string;
   protocol: protocols;

--- a/src/liveNotification.ts
+++ b/src/liveNotification.ts
@@ -26,7 +26,7 @@ import { BaseNotification } from "./notification";
 import { NotificationOptions, protocols } from "./interfaces";
 
 /**
- * @internal
+ * @hidden
  */
 export class LiveNotification extends BaseNotification {
   /** @internal */

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -31,7 +31,7 @@ import {
 } from "./interfaces";
 
 /**
- * @internal
+ * @hidden
  */
 export class BaseNotification {
   /** @internal */

--- a/src/websocketNotification.ts
+++ b/src/websocketNotification.ts
@@ -63,7 +63,7 @@ export class WebsocketNotification extends LiveNotification {
   /** @internal */
   websocket?: IsoWebSocket;
 
-  /** @internal */
+  /** @hidden */
   status: statuses = "closed";
 
   constructor(topic: string, options?: NotificationOptions) {


### PR DESCRIPTION
This PR fixes the failed CD runs where typescript was complaining about `ws.on` and `ws.status` not being in the typescript definitions.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
