### PR TITLE
fix: re-enable support for ESS 1.1 Notifications

### DIFF
--- a/.github/workflows/cd-packaging-tests/bundler-parcel/package.json
+++ b/.github/workflows/cd-packaging-tests/bundler-parcel/package.json
@@ -2,7 +2,7 @@
   "name": "cd-packaging-test-parcel",
   "private": true,
   "dependencies": {
-    "@inrupt/solid-client": "^1.21.0",
-    "@inrupt/solid-client-authn-browser": "^1.11.2"
+    "@inrupt/solid-client": "^1.23.1",
+    "@inrupt/solid-client-authn-browser": "^1.11.8"
   }
 }

--- a/.github/workflows/cd-packaging-tests/bundler-webpack/package.json
+++ b/.github/workflows/cd-packaging-tests/bundler-webpack/package.json
@@ -2,8 +2,8 @@
   "name": "cd-packaging-test-webpack",
   "private": true,
   "dependencies": {
-    "@inrupt/solid-client": "^1.21.0",
-    "@inrupt/solid-client-authn-browser": "^1.11.2",
+    "@inrupt/solid-client": "^1.23.1",
+    "@inrupt/solid-client-authn-browser": "^1.11.8",
     "assert": "^2.0.0",
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",

--- a/.github/workflows/cd-packaging-tests/node/package.json
+++ b/.github/workflows/cd-packaging-tests/node/package.json
@@ -2,7 +2,7 @@
   "name": "cd-packaging-test-node",
   "private": true,
   "dependencies": {
-    "@inrupt/solid-client": "^1.21.0",
-    "@inrupt/solid-client-authn-node": "^1.11.2"
+    "@inrupt/solid-client": "^1.23.1",
+    "@inrupt/solid-client-authn-node": "^1.11.8"
   }
 }

--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -16,9 +16,7 @@ jobs:
       name: ${{ matrix.environment-name }}
     strategy:
       matrix:
-        # disable PodSpaces, as ESS 1.1 doesn't work with getWellKnownSolid yet:
-        # environment-name: ["ESS PodSpaces", "ESS PodSpaces Next"]
-        environment-name: ["ESS PodSpaces Next"]
+        environment-name: ["ESS PodSpaces", "ESS PodSpaces Next"]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 16.x

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -19,9 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version: [16.x]
-        # disable PodSpaces, as ESS 1.1 doesn't work with getWellKnownSolid yet:
-        # environment-name: ["ESS PodSpaces", "ESS PodSpaces Next"]
-        environment-name: ["ESS PodSpaces Next"]
+        environment-name: ["ESS PodSpaces", "ESS PodSpaces Next"]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/e2e/browser/testApp/package-lock.json
+++ b/e2e/browser/testApp/package-lock.json
@@ -8,7 +8,7 @@
       "name": "test-app",
       "version": "0.1.0",
       "dependencies": {
-        "@inrupt/solid-client-authn-browser": "^1.11.7",
+        "@inrupt/solid-client-authn-browser": "^1.11.8",
         "@inrupt/solid-client-notifications": "file:../../../",
         "next": "12.1.5",
         "react": "18.0.0",
@@ -38,10 +38,10 @@
       "devDependencies": {
         "@inrupt/eslint-config-base": "^0.4.0",
         "@inrupt/eslint-config-lib": "^0.4.1",
-        "@inrupt/solid-client": "^1.21.0",
-        "@inrupt/solid-client-authn-browser": "^1.11.2",
-        "@inrupt/solid-client-authn-node": "^1.11.2",
-        "@playwright/test": "^1.20.1",
+        "@inrupt/solid-client": "^1.23.0",
+        "@inrupt/solid-client-authn-browser": "^1.11.8",
+        "@inrupt/solid-client-authn-node": "^1.11.8",
+        "@playwright/test": "^1.21.1",
         "@skypack/package-check": "^0.2.2",
         "@types/dotenv-flow": "^3.2.0",
         "@types/jest": "^27.0.2",
@@ -57,7 +57,6 @@
         "eslint-plugin-jest": "^23.13.2",
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "^27.3.1",
-        "jest-fetch-mock": "^3.0.3",
         "jest-websocket-mock": "^2.2.1",
         "nlfurniss-typedoc-plugin-sourcefile-url": "^2.0.0",
         "node-fetch": "^2.6.6",
@@ -70,6 +69,12 @@
         "typedoc": "^0.22.12",
         "typedoc-plugin-markdown": "^3.11.14",
         "typescript": "^4.6.2"
+      },
+      "engines": {
+        "node": "^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@inrupt/solid-client": "^1.23.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -150,15 +155,14 @@
       }
     },
     "node_modules/@inrupt/oidc-client-ext": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.11.7.tgz",
-      "integrity": "sha512-jSl8NWmZPz9/FW5YHS7EQ9RroT4+Tbo/GRkTU08eW+q9TDscDBE0WFnGndDPFlbGx00Clyq0hVyRYoljPgs7yw==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.11.8.tgz",
+      "integrity": "sha512-LMe9UbH1RocTUzukSQ5mWHtaGb3Qw9lQ+5A1dwLSYL4J7qgh0I9AGgykNTNv/nnchH8I7Yk4/a7oVYv1PpQyfw==",
       "dependencies": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.11.7",
+        "@inrupt/solid-client-authn-core": "^1.11.8",
         "@types/jest": "^27.0.3",
         "@types/uuid": "^8.3.0",
-        "form-urlencoded": "~6.0.3",
         "jose": "^4.3.7",
         "uuid": "^8.3.1"
       }
@@ -175,12 +179,12 @@
       }
     },
     "node_modules/@inrupt/solid-client-authn-browser": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.11.7.tgz",
-      "integrity": "sha512-3DHo+j0jh6aseoFw3LtUXfDqs4lL6JHxRNdcw8Tja2oZanYVRnJKkILc5pGq1pS2EmQe/SvF559wNZFTVbz8bw==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.11.8.tgz",
+      "integrity": "sha512-QOlxr4mRL9wSspgA/ARMtdK1C4o0Mg1fXD+Ideti9Nkqx2+kLxwWLWgp3LtaH5JGDmAnom250HkkU8pv0nNDGg==",
       "dependencies": {
-        "@inrupt/oidc-client-ext": "^1.11.7",
-        "@inrupt/solid-client-authn-core": "^1.11.7",
+        "@inrupt/oidc-client-ext": "^1.11.8",
+        "@inrupt/solid-client-authn-core": "^1.11.8",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/node": "^17.0.2",
         "@types/uuid": "^8.3.0",
@@ -191,9 +195,9 @@
       }
     },
     "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.11.7.tgz",
-      "integrity": "sha512-PjrZ13tmFkamro/+JzE3jURmL7vwzHYUIq81pvn6kTYBa9C/2eHwnZbOZD2T1OplBSddKr9sJshISJJTQc5s6w==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.11.8.tgz",
+      "integrity": "sha512-D7IZn/kBAl1/pC1WVY57FFesVa2fBVScBU6NNqhk9g3m4Hs9vCI1Q51Mi08/9LqYrm/soeNSiIlGWSGJXsC2HQ==",
       "dependencies": {
         "@inrupt/solid-common-vocab": "^1.0.0",
         "@types/lodash.clonedeep": "^4.5.6",
@@ -450,9 +454,9 @@
       "dev": true
     },
     "node_modules/@types/jest": {
-      "version": "27.4.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
-      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.1.tgz",
+      "integrity": "sha512-fUy7YRpT+rHXto1YlL+J9rs0uLGyiqVt3ZOTQR+4ROc47yNl8WLdVLgUloBRhOxP1PZvguHl44T3H0wAWxahYQ==",
       "dependencies": {
         "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
@@ -465,14 +469,14 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.181",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.181.tgz",
-      "integrity": "sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag=="
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
     },
     "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
       "dependencies": {
         "@types/lodash": "*"
       }
@@ -903,9 +907,9 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
-      "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==",
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.5.tgz",
+      "integrity": "sha512-VP/xYuvJ0MJWRAobcmQ8F2H6Bsn+s7zqAAjFaHGBMc5AQm7zaelhD1LGduFn2EehEcQcU+br6t+fwbpQ5d1ZWA==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -1646,11 +1650,6 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
-    "node_modules/form-urlencoded": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-6.0.6.tgz",
-      "integrity": "sha512-5n3L86l3uVJLFk8w+HTcuaV8WrEeH9pPqJcICxAbs3oW/gsKg9kJ8XVPZ3I1PJR50ld2fQjstT94p4G90JDMAg=="
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2120,9 +2119,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.6.0.tgz",
-      "integrity": "sha512-0hNAkhMBNi4soKSAX4zYOFV+aqJlEz/4j4fregvasJzEVtjDChvWqRjPvHwLqr5hx28Ayr6bsOs1Kuj87V0O8w==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
+      "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -3357,26 +3356,25 @@
       }
     },
     "@inrupt/oidc-client-ext": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.11.7.tgz",
-      "integrity": "sha512-jSl8NWmZPz9/FW5YHS7EQ9RroT4+Tbo/GRkTU08eW+q9TDscDBE0WFnGndDPFlbGx00Clyq0hVyRYoljPgs7yw==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.11.8.tgz",
+      "integrity": "sha512-LMe9UbH1RocTUzukSQ5mWHtaGb3Qw9lQ+5A1dwLSYL4J7qgh0I9AGgykNTNv/nnchH8I7Yk4/a7oVYv1PpQyfw==",
       "requires": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.11.7",
+        "@inrupt/solid-client-authn-core": "^1.11.8",
         "@types/jest": "^27.0.3",
         "@types/uuid": "^8.3.0",
-        "form-urlencoded": "~6.0.3",
         "jose": "^4.3.7",
         "uuid": "^8.3.1"
       }
     },
     "@inrupt/solid-client-authn-browser": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.11.7.tgz",
-      "integrity": "sha512-3DHo+j0jh6aseoFw3LtUXfDqs4lL6JHxRNdcw8Tja2oZanYVRnJKkILc5pGq1pS2EmQe/SvF559wNZFTVbz8bw==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.11.8.tgz",
+      "integrity": "sha512-QOlxr4mRL9wSspgA/ARMtdK1C4o0Mg1fXD+Ideti9Nkqx2+kLxwWLWgp3LtaH5JGDmAnom250HkkU8pv0nNDGg==",
       "requires": {
-        "@inrupt/oidc-client-ext": "^1.11.7",
-        "@inrupt/solid-client-authn-core": "^1.11.7",
+        "@inrupt/oidc-client-ext": "^1.11.8",
+        "@inrupt/solid-client-authn-core": "^1.11.8",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/node": "^17.0.2",
         "@types/uuid": "^8.3.0",
@@ -3387,9 +3385,9 @@
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.11.7.tgz",
-      "integrity": "sha512-PjrZ13tmFkamro/+JzE3jURmL7vwzHYUIq81pvn6kTYBa9C/2eHwnZbOZD2T1OplBSddKr9sJshISJJTQc5s6w==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.11.8.tgz",
+      "integrity": "sha512-D7IZn/kBAl1/pC1WVY57FFesVa2fBVScBU6NNqhk9g3m4Hs9vCI1Q51Mi08/9LqYrm/soeNSiIlGWSGJXsC2HQ==",
       "requires": {
         "@inrupt/solid-common-vocab": "^1.0.0",
         "@types/lodash.clonedeep": "^4.5.6",
@@ -3406,10 +3404,10 @@
       "requires": {
         "@inrupt/eslint-config-base": "^0.4.0",
         "@inrupt/eslint-config-lib": "^0.4.1",
-        "@inrupt/solid-client": "^1.21.0",
-        "@inrupt/solid-client-authn-browser": "^1.11.2",
-        "@inrupt/solid-client-authn-node": "^1.11.2",
-        "@playwright/test": "^1.20.1",
+        "@inrupt/solid-client": "^1.23.0",
+        "@inrupt/solid-client-authn-browser": "^1.11.8",
+        "@inrupt/solid-client-authn-node": "^1.11.8",
+        "@playwright/test": "^1.21.1",
         "@skypack/package-check": "^0.2.2",
         "@types/dotenv-flow": "^3.2.0",
         "@types/events": "^3.0.0",
@@ -3430,7 +3428,6 @@
         "events": "^3.3.0",
         "isomorphic-ws": "^4.0.1",
         "jest": "^27.3.1",
-        "jest-fetch-mock": "^3.0.3",
         "jest-websocket-mock": "^2.2.1",
         "nlfurniss-typedoc-plugin-sourcefile-url": "^2.0.0",
         "node-fetch": "^2.6.6",
@@ -3570,9 +3567,9 @@
       "dev": true
     },
     "@types/jest": {
-      "version": "27.4.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
-      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.1.tgz",
+      "integrity": "sha512-fUy7YRpT+rHXto1YlL+J9rs0uLGyiqVt3ZOTQR+4ROc47yNl8WLdVLgUloBRhOxP1PZvguHl44T3H0wAWxahYQ==",
       "requires": {
         "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
@@ -3585,14 +3582,14 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.181",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.181.tgz",
-      "integrity": "sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag=="
+      "version": "4.14.182",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz",
+      "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q=="
     },
     "@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
       "requires": {
         "@types/lodash": "*"
       }
@@ -3885,9 +3882,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.1.tgz",
-      "integrity": "sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig=="
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.5.tgz",
+      "integrity": "sha512-VP/xYuvJ0MJWRAobcmQ8F2H6Bsn+s7zqAAjFaHGBMc5AQm7zaelhD1LGduFn2EehEcQcU+br6t+fwbpQ5d1ZWA=="
     },
     "core-js-pure": {
       "version": "3.21.1",
@@ -4473,11 +4470,6 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
-    "form-urlencoded": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-6.0.6.tgz",
-      "integrity": "sha512-5n3L86l3uVJLFk8w+HTcuaV8WrEeH9pPqJcICxAbs3oW/gsKg9kJ8XVPZ3I1PJR50ld2fQjstT94p4G90JDMAg=="
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4803,9 +4795,9 @@
       }
     },
     "jose": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.6.0.tgz",
-      "integrity": "sha512-0hNAkhMBNi4soKSAX4zYOFV+aqJlEz/4j4fregvasJzEVtjDChvWqRjPvHwLqr5hx28Ayr6bsOs1Kuj87V0O8w=="
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
+      "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/e2e/browser/testApp/package.json
+++ b/e2e/browser/testApp/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@inrupt/solid-client-authn-browser": "^1.11.7",
+    "@inrupt/solid-client-authn-browser": "^1.11.8",
     "@inrupt/solid-client-notifications": "file:../../../",
     "next": "12.1.5",
     "react": "18.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
       "devDependencies": {
         "@inrupt/eslint-config-base": "^0.4.0",
         "@inrupt/eslint-config-lib": "^0.4.1",
-        "@inrupt/solid-client": "^1.21.0",
-        "@inrupt/solid-client-authn-browser": "^1.11.2",
-        "@inrupt/solid-client-authn-node": "^1.11.2",
+        "@inrupt/solid-client": "^1.23.1",
+        "@inrupt/solid-client-authn-browser": "^1.11.8",
+        "@inrupt/solid-client-authn-node": "^1.11.8",
         "@playwright/test": "^1.21.1",
         "@skypack/package-check": "^0.2.2",
         "@types/dotenv-flow": "^3.2.0",
@@ -55,7 +55,111 @@
         "node": "^14.17.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "@inrupt/solid-client": "^1.21.0"
+        "@inrupt/solid-client": "^1.23.1"
+      }
+    },
+    "../digitalbazaar/jsonld.js": {
+      "name": "jsonld",
+      "version": "5.2.1-0",
+      "extraneous": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@digitalbazaar/http-client": "^3.2.0",
+        "canonicalize": "^1.0.1",
+        "lru-cache": "^7.10.1",
+        "rdf-canonize": "^3.0.0"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.13.14",
+        "@babel/plugin-proposal-object-rest-spread": "^7.13.8",
+        "@babel/plugin-transform-modules-commonjs": "^7.13.8",
+        "@babel/plugin-transform-runtime": "^7.13.10",
+        "@babel/preset-env": "^7.13.12",
+        "@babel/runtime": "^7.13.10",
+        "babel-loader": "^8.2.2",
+        "benchmark": "^2.1.4",
+        "browserify": "^17.0.0",
+        "chai": "^4.3.4",
+        "core-js": "^3.10.0",
+        "cors": "^2.7.1",
+        "cross-env": "^7.0.3",
+        "envify": "^4.1.0",
+        "eslint": "^7.23.0",
+        "eslint-config-digitalbazaar": "^2.6.1",
+        "esmify": "^2.1.1",
+        "express": "^4.16.4",
+        "fs-extra": "^9.1.0",
+        "join-path-js": "0.0.0",
+        "karma": "^5.2.3",
+        "karma-babel-preprocessor": "^8.0.1",
+        "karma-browserify": "^8.0.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^2.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^2.0.1",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-server-side": "^1.7.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^4.0.2",
+        "mocha": "^8.3.2",
+        "mocha-lcov-reporter": "^1.3.0",
+        "nyc": "^15.1.0",
+        "watchify": "^3.11.1",
+        "webpack": "^4.46.0",
+        "webpack-cli": "^4.5.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "../solid-client-js": {
+      "name": "@inrupt/solid-client",
+      "version": "1.23.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/dataset": "^1.1.0",
+        "@rdfjs/types": "^1.1.0",
+        "@types/n3": "^1.10.0",
+        "@types/rdfjs__dataset": "^1.0.4",
+        "cross-fetch": "^3.0.4",
+        "http-link-header": "^1.0.2",
+        "jsonld": "^5.2.0",
+        "n3": "^1.10.0"
+      },
+      "devDependencies": {
+        "@inrupt/solid-client-authn-node": "^1.10.1",
+        "@playwright/test": "^1.20.0",
+        "@skypack/package-check": "^0.2.2",
+        "@types/dotenv-flow": "^3.1.0",
+        "@types/http-link-header": "^1.0.1",
+        "@types/jest": "^27.0.0",
+        "@types/jsonld": "^1.5.6",
+        "@typescript-eslint/eslint-plugin": "^5.11.0",
+        "@typescript-eslint/parser": "^5.11.0",
+        "dotenv-flow": "^3.2.0",
+        "eslint": "^8.8.0",
+        "eslint-config-next": "^12.1.4",
+        "eslint-plugin-jest": "^26.1.0",
+        "eslint-plugin-license-header": "^0.4.0",
+        "fast-check": "^2.2.0",
+        "jest": "^27.0.4",
+        "license-checker": "^25.0.1",
+        "prettier": "2.6.2",
+        "rdf-namespaces": "^1.8.0",
+        "rollup": "^2.15.0",
+        "rollup-plugin-typescript2": "^0.31.0",
+        "ts-jest": "^27.0.3",
+        "typedoc": "^0.22.12",
+        "typedoc-plugin-markdown": "^3.11.14",
+        "typescript": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1059,33 +1163,37 @@
         "@inrupt/eslint-config-base": "^0.4.0"
       }
     },
-    "node_modules/@inrupt/jose-legacy-modules": {
-      "version": "0.0.3-3.15.4",
-      "resolved": "https://registry.npmjs.org/@inrupt/jose-legacy-modules/-/jose-legacy-modules-0.0.3-3.15.4.tgz",
-      "integrity": "sha512-gcmIqLLFyhNZWw9OKK3kNgEbpKU0z6kn6NPWQlJf0Dy5QtuIgwcS7aRU2GJScz+Dx9KGQVvyAapYX3buHyrBXw==",
+    "node_modules/@inrupt/oidc-client": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client/-/oidc-client-1.11.6.tgz",
+      "integrity": "sha512-1rCTk1T6pdm/7gKozutZutk7jwmYBADlnkGGoI5ypke099NOCa5KFXjkQpbjsps0PRkKZ+0EaR70XN5+xqmViA==",
       "dev": true,
       "dependencies": {
-        "jose": "3.15.4"
+        "acorn": "^7.4.1",
+        "base64-js": "^1.5.1",
+        "core-js": "^3.8.3",
+        "crypto-js": "^4.0.0",
+        "serialize-javascript": "^4.0.0"
       }
     },
     "node_modules/@inrupt/oidc-client-ext": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.11.2.tgz",
-      "integrity": "sha512-htdqsFnLOSUhi+AkhyYCTA1vjUsZT8TeQOiXEtLDgneCRxwxCGfRwVSgXSC30OeophlgrZ7/QVixaz3BB5yXEA==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.11.8.tgz",
+      "integrity": "sha512-LMe9UbH1RocTUzukSQ5mWHtaGb3Qw9lQ+5A1dwLSYL4J7qgh0I9AGgykNTNv/nnchH8I7Yk4/a7oVYv1PpQyfw==",
       "dev": true,
       "dependencies": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
-        "@inrupt/solid-client-authn-core": "^1.11.2",
+        "@inrupt/oidc-client": "^1.11.6",
+        "@inrupt/solid-client-authn-core": "^1.11.8",
+        "@types/jest": "^27.0.3",
         "@types/uuid": "^8.3.0",
-        "form-urlencoded": "~6.0.3",
-        "oidc-client": "^1.11.3",
+        "jose": "^4.3.7",
         "uuid": "^8.3.1"
       }
     },
     "node_modules/@inrupt/solid-client": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.21.0.tgz",
-      "integrity": "sha512-RGuo5ThcsRC0fYWmDoDPcudRzMa3am4oAbki9cdoztodWqwnivnwcQALFPpBYupYymlOTk/OIvdxg8YFdBcewA==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.23.1.tgz",
+      "integrity": "sha512-M1MyS0Qd9FjedppFctnpfAO8x046VIcmFOt9SHU3/1aDTGQrgNIqGeIBRCDwUvCRVvfvmpYE9Q9BdnA2gHAgzQ==",
       "dev": true,
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
@@ -1096,67 +1204,80 @@
         "http-link-header": "^1.0.2",
         "jsonld": "^5.2.0",
         "n3": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@inrupt/solid-client-authn-browser": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.11.2.tgz",
-      "integrity": "sha512-DifF7hSMuFEB9+lDAYjRq6E7DOIZjQwdk9gUkPj93tdIb4icHXQ9JTMwBAxXmdTruPC2g5Pzu0PQ0PCvbIpuDA==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.11.8.tgz",
+      "integrity": "sha512-QOlxr4mRL9wSspgA/ARMtdK1C4o0Mg1fXD+Ideti9Nkqx2+kLxwWLWgp3LtaH5JGDmAnom250HkkU8pv0nNDGg==",
       "dev": true,
       "dependencies": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
-        "@inrupt/oidc-client-ext": "^1.11.2",
-        "@inrupt/solid-client-authn-core": "^1.11.2",
+        "@inrupt/oidc-client-ext": "^1.11.8",
+        "@inrupt/solid-client-authn-core": "^1.11.8",
         "@types/lodash.clonedeep": "^4.5.6",
-        "@types/node": "^15.0.1",
+        "@types/node": "^17.0.2",
         "@types/uuid": "^8.3.0",
         "events": "^3.3.0",
+        "jose": "^4.3.7",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^8.3.1"
       }
     },
     "node_modules/@inrupt/solid-client-authn-browser/node_modules/@types/node": {
-      "version": "15.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
+      "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
       "dev": true
     },
     "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.11.2.tgz",
-      "integrity": "sha512-hL+BC81lE4V0EXZE8PJ418y/vFvW+rfcmHgHqi0ZKSSxLNVE08Ok4W2d+g6wcW3wyePZ9FOL2K8BIh7/jCGj8Q==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.11.8.tgz",
+      "integrity": "sha512-D7IZn/kBAl1/pC1WVY57FFesVa2fBVScBU6NNqhk9g3m4Hs9vCI1Q51Mi08/9LqYrm/soeNSiIlGWSGJXsC2HQ==",
       "dev": true,
       "dependencies": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
         "@inrupt/solid-common-vocab": "^1.0.0",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/uuid": "^8.3.0",
         "cross-fetch": "^3.0.6",
         "events": "^3.3.0",
+        "jose": "^4.3.7",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^8.3.1"
       }
     },
     "node_modules/@inrupt/solid-client-authn-node": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.11.2.tgz",
-      "integrity": "sha512-APgqEoN7Wuh/A/FtvBu4NQsdZmxY34TprGacU79s1bUpPTU7dPaLEWAyeX/zb/qElbZPZkOlGVX4qUcILJDIFw==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.11.8.tgz",
+      "integrity": "sha512-bwo8HfDrZMZ8dDPwTn7K57jj83nmo6gR5s0VkkEDZCmiJXJnbAPGkLVYRWB8SeWvUaGMgRkj7eX6/vKETpnB7A==",
       "dev": true,
       "dependencies": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
-        "@inrupt/solid-client-authn-core": "^1.11.2",
-        "@types/node": "^15.0.1",
-        "@types/uuid": "^8.3.0",
+        "@inrupt/solid-client-authn-core": "^1.11.8",
         "cross-fetch": "^3.0.6",
-        "openid-client": "^4.2.2",
+        "jose": "^4.3.7",
+        "openid-client": "^5.1.0",
         "uuid": "^8.3.2"
       }
     },
-    "node_modules/@inrupt/solid-client-authn-node/node_modules/@types/node": {
-      "version": "15.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
-      "dev": true
+    "node_modules/@inrupt/solid-client-authn-node/node_modules/openid-client": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.6.tgz",
+      "integrity": "sha512-HTFaXWdUHvLFw4GaEMgC0jXYBgpjgzQQNHW1pZsSqJorSgrXzxJ+4u/LWCGaClDEse5HLjXRV+zU5Bn3OefiZw==",
+      "dev": true,
+      "dependencies": {
+        "jose": "^4.1.4",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.0.1",
+        "oidc-token-hash": "^5.0.1"
+      },
+      "engines": {
+        "node": "^12.19.0 || ^14.15.0 || ^16.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/@inrupt/solid-common-vocab": {
       "version": "1.0.0",
@@ -3056,9 +3177,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.3.tgz",
-      "integrity": "sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g==",
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.5.tgz",
+      "integrity": "sha512-VP/xYuvJ0MJWRAobcmQ8F2H6Bsn+s7zqAAjFaHGBMc5AQm7zaelhD1LGduFn2EehEcQcU+br6t+fwbpQ5d1ZWA==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -4344,12 +4465,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/form-urlencoded": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-6.0.5.tgz",
-      "integrity": "sha512-7M7IhZNujsHqjYovM1WTSqcAVOqfvgF8acu6ok1ct1a00l6LVrmagJKkOdRUH/PYKEDOZ7ZAw/Mtq1/Q8CuRTQ==",
-      "dev": true
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -6160,9 +6275,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "3.15.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-3.15.4.tgz",
-      "integrity": "sha512-SXeGi+g5ZcNgV6o7f+Mx3Q1gaYMSBzAi3cmcZPxoeCEZPgfSCnnyfmMXzXoLDh+XL4KMtGvhOsYBoqQhnuR2rQ==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
+      "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -6664,9 +6779,9 @@
       "dev": true
     },
     "node_modules/n3": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.0.tgz",
-      "integrity": "sha512-gE5KF07yhGXhEdAVru5QUqC4fKltA4sMwgASWpOrZSwn8fi8cuLHYPjRl9pR5WhQL96lhaNMZwT8enRIayVfLg==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.2.tgz",
+      "integrity": "sha512-5vYa2HuNEJ+a26FEs4FGgfFLgaPOODaZpJlc7FS0eUjDumc4uK0cvx216PjKXBkLzmAsSqGgQPwqztcLLvwDsw==",
       "dev": true,
       "dependencies": {
         "queue-microtask": "^1.1.2",
@@ -6674,20 +6789,6 @@
       },
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/n3/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/natural-compare": {
@@ -6874,19 +6975,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/oidc-client": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.5.tgz",
-      "integrity": "sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^7.4.1",
-        "base64-js": "^1.5.1",
-        "core-js": "^3.8.3",
-        "crypto-js": "^4.0.0",
-        "serialize-javascript": "^4.0.0"
       }
     },
     "node_modules/oidc-token-hash": {
@@ -7487,6 +7575,20 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -7880,13 +7982,33 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -9505,33 +9627,37 @@
       "dev": true,
       "requires": {}
     },
-    "@inrupt/jose-legacy-modules": {
-      "version": "0.0.3-3.15.4",
-      "resolved": "https://registry.npmjs.org/@inrupt/jose-legacy-modules/-/jose-legacy-modules-0.0.3-3.15.4.tgz",
-      "integrity": "sha512-gcmIqLLFyhNZWw9OKK3kNgEbpKU0z6kn6NPWQlJf0Dy5QtuIgwcS7aRU2GJScz+Dx9KGQVvyAapYX3buHyrBXw==",
+    "@inrupt/oidc-client": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client/-/oidc-client-1.11.6.tgz",
+      "integrity": "sha512-1rCTk1T6pdm/7gKozutZutk7jwmYBADlnkGGoI5ypke099NOCa5KFXjkQpbjsps0PRkKZ+0EaR70XN5+xqmViA==",
       "dev": true,
       "requires": {
-        "jose": "3.15.4"
+        "acorn": "^7.4.1",
+        "base64-js": "^1.5.1",
+        "core-js": "^3.8.3",
+        "crypto-js": "^4.0.0",
+        "serialize-javascript": "^4.0.0"
       }
     },
     "@inrupt/oidc-client-ext": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.11.2.tgz",
-      "integrity": "sha512-htdqsFnLOSUhi+AkhyYCTA1vjUsZT8TeQOiXEtLDgneCRxwxCGfRwVSgXSC30OeophlgrZ7/QVixaz3BB5yXEA==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.11.8.tgz",
+      "integrity": "sha512-LMe9UbH1RocTUzukSQ5mWHtaGb3Qw9lQ+5A1dwLSYL4J7qgh0I9AGgykNTNv/nnchH8I7Yk4/a7oVYv1PpQyfw==",
       "dev": true,
       "requires": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
-        "@inrupt/solid-client-authn-core": "^1.11.2",
+        "@inrupt/oidc-client": "^1.11.6",
+        "@inrupt/solid-client-authn-core": "^1.11.8",
+        "@types/jest": "^27.0.3",
         "@types/uuid": "^8.3.0",
-        "form-urlencoded": "~6.0.3",
-        "oidc-client": "^1.11.3",
+        "jose": "^4.3.7",
         "uuid": "^8.3.1"
       }
     },
     "@inrupt/solid-client": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.21.0.tgz",
-      "integrity": "sha512-RGuo5ThcsRC0fYWmDoDPcudRzMa3am4oAbki9cdoztodWqwnivnwcQALFPpBYupYymlOTk/OIvdxg8YFdBcewA==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.23.1.tgz",
+      "integrity": "sha512-M1MyS0Qd9FjedppFctnpfAO8x046VIcmFOt9SHU3/1aDTGQrgNIqGeIBRCDwUvCRVvfvmpYE9Q9BdnA2gHAgzQ==",
       "dev": true,
       "requires": {
         "@rdfjs/dataset": "^1.1.0",
@@ -9545,66 +9671,70 @@
       }
     },
     "@inrupt/solid-client-authn-browser": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.11.2.tgz",
-      "integrity": "sha512-DifF7hSMuFEB9+lDAYjRq6E7DOIZjQwdk9gUkPj93tdIb4icHXQ9JTMwBAxXmdTruPC2g5Pzu0PQ0PCvbIpuDA==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.11.8.tgz",
+      "integrity": "sha512-QOlxr4mRL9wSspgA/ARMtdK1C4o0Mg1fXD+Ideti9Nkqx2+kLxwWLWgp3LtaH5JGDmAnom250HkkU8pv0nNDGg==",
       "dev": true,
       "requires": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
-        "@inrupt/oidc-client-ext": "^1.11.2",
-        "@inrupt/solid-client-authn-core": "^1.11.2",
+        "@inrupt/oidc-client-ext": "^1.11.8",
+        "@inrupt/solid-client-authn-core": "^1.11.8",
         "@types/lodash.clonedeep": "^4.5.6",
-        "@types/node": "^15.0.1",
+        "@types/node": "^17.0.2",
         "@types/uuid": "^8.3.0",
         "events": "^3.3.0",
+        "jose": "^4.3.7",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^8.3.1"
       },
       "dependencies": {
         "@types/node": {
-          "version": "15.14.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-          "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
+          "version": "17.0.35",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.35.tgz",
+          "integrity": "sha512-vu1SrqBjbbZ3J6vwY17jBs8Sr/BKA+/a/WtjRG+whKg1iuLFOosq872EXS0eXWILdO36DHQQeku/ZcL6hz2fpg==",
           "dev": true
         }
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.11.2.tgz",
-      "integrity": "sha512-hL+BC81lE4V0EXZE8PJ418y/vFvW+rfcmHgHqi0ZKSSxLNVE08Ok4W2d+g6wcW3wyePZ9FOL2K8BIh7/jCGj8Q==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.11.8.tgz",
+      "integrity": "sha512-D7IZn/kBAl1/pC1WVY57FFesVa2fBVScBU6NNqhk9g3m4Hs9vCI1Q51Mi08/9LqYrm/soeNSiIlGWSGJXsC2HQ==",
       "dev": true,
       "requires": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
         "@inrupt/solid-common-vocab": "^1.0.0",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/uuid": "^8.3.0",
         "cross-fetch": "^3.0.6",
         "events": "^3.3.0",
+        "jose": "^4.3.7",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^8.3.1"
       }
     },
     "@inrupt/solid-client-authn-node": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.11.2.tgz",
-      "integrity": "sha512-APgqEoN7Wuh/A/FtvBu4NQsdZmxY34TprGacU79s1bUpPTU7dPaLEWAyeX/zb/qElbZPZkOlGVX4qUcILJDIFw==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.11.8.tgz",
+      "integrity": "sha512-bwo8HfDrZMZ8dDPwTn7K57jj83nmo6gR5s0VkkEDZCmiJXJnbAPGkLVYRWB8SeWvUaGMgRkj7eX6/vKETpnB7A==",
       "dev": true,
       "requires": {
-        "@inrupt/jose-legacy-modules": "0.0.3-3.15.4",
-        "@inrupt/solid-client-authn-core": "^1.11.2",
-        "@types/node": "^15.0.1",
-        "@types/uuid": "^8.3.0",
+        "@inrupt/solid-client-authn-core": "^1.11.8",
         "cross-fetch": "^3.0.6",
-        "openid-client": "^4.2.2",
+        "jose": "^4.3.7",
+        "openid-client": "^5.1.0",
         "uuid": "^8.3.2"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "15.14.9",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-          "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
-          "dev": true
+        "openid-client": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.6.tgz",
+          "integrity": "sha512-HTFaXWdUHvLFw4GaEMgC0jXYBgpjgzQQNHW1pZsSqJorSgrXzxJ+4u/LWCGaClDEse5HLjXRV+zU5Bn3OefiZw==",
+          "dev": true,
+          "requires": {
+            "jose": "^4.1.4",
+            "lru-cache": "^6.0.0",
+            "object-hash": "^2.0.1",
+            "oidc-token-hash": "^5.0.1"
+          }
         }
       }
     },
@@ -11069,9 +11199,9 @@
       }
     },
     "core-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.3.tgz",
-      "integrity": "sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g==",
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.5.tgz",
+      "integrity": "sha512-VP/xYuvJ0MJWRAobcmQ8F2H6Bsn+s7zqAAjFaHGBMc5AQm7zaelhD1LGduFn2EehEcQcU+br6t+fwbpQ5d1ZWA==",
       "dev": true
     },
     "cross-fetch": {
@@ -12040,12 +12170,6 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
-    },
-    "form-urlencoded": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-6.0.5.tgz",
-      "integrity": "sha512-7M7IhZNujsHqjYovM1WTSqcAVOqfvgF8acu6ok1ct1a00l6LVrmagJKkOdRUH/PYKEDOZ7ZAw/Mtq1/Q8CuRTQ==",
-      "dev": true
     },
     "fs-extra": {
       "version": "10.1.0",
@@ -13381,9 +13505,9 @@
       }
     },
     "jose": {
-      "version": "3.15.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-3.15.4.tgz",
-      "integrity": "sha512-SXeGi+g5ZcNgV6o7f+Mx3Q1gaYMSBzAi3cmcZPxoeCEZPgfSCnnyfmMXzXoLDh+XL4KMtGvhOsYBoqQhnuR2rQ==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.8.1.tgz",
+      "integrity": "sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==",
       "dev": true
     },
     "jpeg-js": {
@@ -13759,26 +13883,13 @@
       "dev": true
     },
     "n3": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.0.tgz",
-      "integrity": "sha512-gE5KF07yhGXhEdAVru5QUqC4fKltA4sMwgASWpOrZSwn8fi8cuLHYPjRl9pR5WhQL96lhaNMZwT8enRIayVfLg==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.2.tgz",
+      "integrity": "sha512-5vYa2HuNEJ+a26FEs4FGgfFLgaPOODaZpJlc7FS0eUjDumc4uK0cvx216PjKXBkLzmAsSqGgQPwqztcLLvwDsw==",
       "dev": true,
       "requires": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "natural-compare": {
@@ -13918,19 +14029,6 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1"
-      }
-    },
-    "oidc-client": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.5.tgz",
-      "integrity": "sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==",
-      "dev": true,
-      "requires": {
-        "acorn": "^7.4.1",
-        "base64-js": "^1.5.1",
-        "core-js": "^3.8.3",
-        "crypto-js": "^4.0.0",
-        "serialize-javascript": "^4.0.0"
       }
     },
     "oidc-token-hash": {
@@ -14366,6 +14464,17 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -14658,12 +14767,20 @@
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
       }
     },
     "string-length": {

--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
   "devDependencies": {
     "@inrupt/eslint-config-base": "^0.4.0",
     "@inrupt/eslint-config-lib": "^0.4.1",
-    "@inrupt/solid-client": "^1.21.0",
-    "@inrupt/solid-client-authn-browser": "^1.11.2",
-    "@inrupt/solid-client-authn-node": "^1.11.2",
+    "@inrupt/solid-client": "^1.23.1",
+    "@inrupt/solid-client-authn-browser": "^1.11.8",
+    "@inrupt/solid-client-authn-node": "^1.11.8",
     "@playwright/test": "^1.21.1",
     "@skypack/package-check": "^0.2.2",
     "@types/dotenv-flow": "^3.2.0",
@@ -103,7 +103,7 @@
     "ws": "^7.5.5"
   },
   "peerDependencies": {
-    "@inrupt/solid-client": "^1.21.0"
+    "@inrupt/solid-client": "^1.23.1"
   },
   "engines": {
     "node": "^14.17.0 || >=16.0.0"

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -42,7 +42,13 @@ export class NotImplementedError extends Error {
 }
 
 export class NotSupported extends Error {
-  constructor(message = "The server appears to not support notifications") {
-    super(message);
+  cause?: Error;
+
+  constructor(cause?: Error) {
+    super("The server appears to not support notifications");
+    if (cause) {
+      this.message = `The server appears to not support notifications: ${cause.toString()}`;
+      this.cause = cause;
+    }
   }
 }

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -138,11 +138,13 @@ export class BaseNotification {
       return this.gateway;
     }
 
-    const wellKnown = await getWellKnownSolid(this.topic).catch(() => {
-      // The storage server for the topic resource didn't respond well to
-      // getWellKnownSolid requests:
-      throw new NotSupported();
-    });
+    const wellKnown = await getWellKnownSolid(this.topic).catch(
+      (err: Error) => {
+        // The storage server for the topic resource didn't respond well to
+        // getWellKnownSolid requests:
+        throw new NotSupported(err);
+      }
+    );
 
     const wellKnownSubjects = getThingAll(wellKnown, {
       acceptBlankNodes: true,

--- a/src/websocketNotification.ts
+++ b/src/websocketNotification.ts
@@ -45,7 +45,7 @@ export declare interface WebsocketNotification {
    * Activity](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-activity).
    */
   // TODO: use more specific type than object in the future
-  on(event: "message", listener: (payload: object) => void): this;
+  on(event: "message", listener: (notification: object) => void): this;
 
   /**
    * Emitted when an error is encountered on the WebSocket
@@ -75,8 +75,7 @@ export declare interface WebsocketNotification {
  *   fetch: session.fetch,
  * });
  *
- * socket.on("message", (message) => {
- *   const notification = JSON.parse(message);
+ * socket.on("message", (notification) => {
  *   console.log("Change:", notification);
  * });
  *


### PR DESCRIPTION
Due to a bug in `@inrupt/solid-client`, we had to temporarily disable support for ESS 1.1 notifications as we couldn't correctly retrieve the data required to find the notifications gateway / storage metadata. We've fixed that bug as of `@inrupt/solid-client@1.23.1`

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
