### PR TITLE
release: prepare v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 The following changes have been implemented but not released yet:
 
-## [Unreleased]
+## [1.0.0] - 2022-06-06
 
 ### Breaking Changes
 

--- a/e2e/browser/testApp/package-lock.json
+++ b/e2e/browser/testApp/package-lock.json
@@ -25,7 +25,7 @@
     },
     "../../..": {
       "name": "@inrupt/solid-client-notifications",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/events": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client-notifications",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client-notifications",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/events": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client-notifications",
   "description": "Receive notifications linked to Solid resources.",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "license": "MIT",
   "scripts": {
     "clean": "rimraf dist umd",


### PR DESCRIPTION
This PR bumps the version to v1.0.0.

# Checklist

- [x] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [ ] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
