### PR TITLE
Run Sonar analysis with test coverage on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,17 @@ jobs:
       - run: npm run build
       - run: npm test
 
+      # Sonar analysis needs the full history for features like automatic assignment of bugs. If the following step
+      # is not included the project will show a warning about incomplete information.
+      - run: git fetch --unshallow
+        if: ${{ matrix.node-version == '16.x' && matrix.os == 'ubuntu-latest' }}
+      # Run Sonar analysis on just the latest ubuntu/node runner.
+      - uses: SonarSource/sonarcloud-github-action@v1.6
+        if: ${{ matrix.node-version == '16.x' && matrix.os == 'ubuntu-latest' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   lint:
     # FIXME: use a fixed version after it has been released
     uses: inrupt/javascript-style-configs/.github/workflows/reusable-lint.yml@main

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
   testEnvironment: "<rootDir>/tests/environment/customEnvironment.js",
   clearMocks: true,
   collectCoverage: true,
-  coverageReporters: ["text"],
+  coverageReporters: process.env.CI ? ["text", "lcov"] : ["text"],
   coverageThreshold: {
     global: {
       branches: 100,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+sonar.projectKey=inrupt_solid-client-notifications-js
+sonar.organization=inrupt
+
+# Path is relative to the sonar-project.properties file. Defaults to .
+sonar.sources=src
+
+# Path to Tests and coverage results
+#sonar.tests=test
+
+# Typescript tsconfigPath JSON file
+sonar.typescript.tsconfigPath=.
+
+# Comma-delimited list of paths to LCOV coverage report files. Paths may be absolute or relative to the project root.
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+
+sonar.exclusions=**/*.test.ts


### PR DESCRIPTION
This adds a CI workflow to run a SonarCloud Scan on each PR, including unit tests and the coverage report. The results are added to SonarCloud.