### PR TITLE
Feat/off once support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
     "max-classes-per-file": 0,
     "jest/no-disabled-tests": 1,
     "no-shadow": [1, { allow: ["NotificationOptions"] }],
+    "@typescript-eslint/adjacent-overload-signatures": 0
   },
   parserOptions: {
     project: "./tsconfig.eslint.json",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,8 @@ module.exports = {
     "max-classes-per-file": 0,
     "jest/no-disabled-tests": 1,
     "no-shadow": [1, { allow: ["NotificationOptions"] }],
+    // This is required to group methods by event type
+    // rather than method name in WebsocketNotification
     "@typescript-eslint/adjacent-overload-signatures": 0
   },
   parserOptions: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+### New Features
+ - LiveNotification now supports `once` and `off` events.
+
 ## [1.0.0] - 2022-06-06
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 The following changes have been implemented but not released yet:
 
 ### New Features
- - LiveNotification now supports `once` and `off` events.
+
+- LiveNotification now supports `once` and `off` events.
 
 ## [1.0.0] - 2022-06-06
 

--- a/src/liveNotification.test.ts
+++ b/src/liveNotification.test.ts
@@ -51,7 +51,7 @@ describe("LiveNotification", () => {
     expect(notification.status).toEqual("closed");
   });
 
-  test("on forwards events from the eventemitter", () => {
+  test("on forwards events from the eventemitter until off is called", () => {
     const topic = "https://fake.url/some-resource";
     const protocol = ["ws"] as Array<protocols>;
     const notification = new LiveNotification(topic, protocol);
@@ -65,5 +65,32 @@ describe("LiveNotification", () => {
     notification.emitter.emit(channel, message);
 
     expect(onFn).toHaveBeenCalledWith(message);
+    expect(onFn).toHaveBeenCalledTimes(1);
+
+    notification.emitter.emit(channel, message);
+    expect(onFn).toHaveBeenCalledTimes(2);
+
+    notification.off(channel, onFn);
+    notification.emitter.emit(channel, message);
+    expect(onFn).toHaveBeenCalledTimes(2);
+  });
+  test("once forwards events from the eventemitter once", () => {
+    const topic = "https://fake.url/some-resource";
+    const protocol = ["ws"] as Array<protocols>;
+    const notification = new LiveNotification(topic, protocol);
+
+    const channel = "message";
+    const message = "hello";
+    const onFn = jest.fn();
+
+    notification.once(channel, onFn);
+
+    notification.emitter.emit(channel, message);
+
+    expect(onFn).toHaveBeenCalledWith(message);
+    expect(onFn).toHaveBeenCalledTimes(1);
+
+    notification.emitter.emit(channel, message);
+    expect(onFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/liveNotification.ts
+++ b/src/liveNotification.ts
@@ -27,6 +27,8 @@ import { NotificationOptions, protocols } from "./interfaces";
 
 export declare interface LiveNotification {
   on(eventName: string, listener: (...args: any[]) => void): this;
+  once(eventName: string, listener: (...args: any[]) => void): this;
+  off(eventName: string, listener: (...args: any[]) => void): this;
 }
 
 /**
@@ -62,6 +64,18 @@ export class LiveNotification extends BaseNotification {
   /* eslint @typescript-eslint/no-explicit-any: 0 */
   on(eventName: string, listener: (...args: any[]) => void): this {
     this.emitter.on(eventName, listener);
+    return this;
+  }
+
+  /* eslint @typescript-eslint/no-explicit-any: 0 */
+  once(eventName: string | symbol, listener: (...args: any[]) => void): this {
+    this.emitter.once(eventName, listener);
+    return this;
+  }
+
+  /* eslint @typescript-eslint/no-explicit-any: 0 */
+  off(eventName: string, listener: (...args: any[]) => void): this {
+    this.emitter.off(eventName, listener);
     return this;
   }
 }

--- a/src/websocketNotification.ts
+++ b/src/websocketNotification.ts
@@ -34,9 +34,12 @@ export declare interface WebsocketNotification {
    */
   on(event: "connected", listener: () => void): this;
   /**
-   * Emitted when the connection is established
+   * Emitted when the next connection is established
    */
   once(event: "connected", listener: () => void): this;
+  /**
+   * Removes a listener for the "connected" event
+   */
   off(event: "connected", listener: () => void): this;
 
   /**
@@ -44,9 +47,12 @@ export declare interface WebsocketNotification {
    */
   on(event: "closed", listener: () => void): this;
   /**
-   * Emitted when the connection is closed
+   * Emitted when the next connection is closed
    */
   once(event: "closed", listener: () => void): this;
+  /**
+   * Removes a listener for the "closed" event
+   */
   off(event: "closed", listener: () => void): this;
 
   /**
@@ -57,16 +63,14 @@ export declare interface WebsocketNotification {
   // TODO: use more specific type than object in the future
   on(event: "message", listener: (notification: object) => void): this;
   /**
-   * Emitted when a valid notification is received, the payload is a
+   * Emitted when the next valid notification is received, the payload is a
    * [activitystreams
    * Activity](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-activity).
    */
   // TODO: use more specific type than object in the future
   once(event: "message", listener: (notification: object) => void): this;
   /**
-   * Emitted when a valid notification is received, the payload is a
-   * [activitystreams
-   * Activity](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-activity).
+   * Removes a listener for the "message" event
    */
   // TODO: use more specific type than object in the future
   off(event: "message", listener: (notification: object) => void): this;
@@ -76,11 +80,11 @@ export declare interface WebsocketNotification {
    */
   on(event: "error", listener: (error: ErrorEvent) => void): this;
   /**
-   * Emitted when an error is encountered on the WebSocket
+   * Emitted when the next error is encountered on the WebSocket
    */
   once(event: "error", listener: (error: ErrorEvent) => void): this;
   /**
-   * Emitted when an error is encountered on the WebSocket
+   * Removes a listener for the "error" event
    */
   off(event: "error", listener: (error: ErrorEvent) => void): this;
 }

--- a/src/websocketNotification.ts
+++ b/src/websocketNotification.ts
@@ -63,6 +63,11 @@ export declare interface WebsocketNotification {
    */
   // TODO: use more specific type than object in the future
   once(event: "message", listener: (notification: object) => void): this;
+  /**
+   * Emitted when a valid notification is received, the payload is a
+   * [activitystreams
+   * Activity](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-activity).
+   */
   // TODO: use more specific type than object in the future
   off(event: "message", listener: (notification: object) => void): this;
 
@@ -74,6 +79,9 @@ export declare interface WebsocketNotification {
    * Emitted when an error is encountered on the WebSocket
    */
   once(event: "error", listener: (error: ErrorEvent) => void): this;
+  /**
+   * Emitted when an error is encountered on the WebSocket
+   */
   off(event: "error", listener: (error: ErrorEvent) => void): this;
 }
 

--- a/src/websocketNotification.ts
+++ b/src/websocketNotification.ts
@@ -33,11 +33,21 @@ export declare interface WebsocketNotification {
    * Emitted when the connection is established
    */
   on(event: "connected", listener: () => void): this;
+  /**
+   * Emitted when the connection is established
+   */
+  once(event: "connected", listener: () => void): this;
+  off(event: "connected", listener: () => void): this;
 
   /**
    * Emitted when the connection is closed
    */
   on(event: "closed", listener: () => void): this;
+  /**
+   * Emitted when the connection is closed
+   */
+  once(event: "closed", listener: () => void): this;
+  off(event: "closed", listener: () => void): this;
 
   /**
    * Emitted when a valid notification is received, the payload is a
@@ -46,11 +56,25 @@ export declare interface WebsocketNotification {
    */
   // TODO: use more specific type than object in the future
   on(event: "message", listener: (notification: object) => void): this;
+  /**
+   * Emitted when a valid notification is received, the payload is a
+   * [activitystreams
+   * Activity](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-activity).
+   */
+  // TODO: use more specific type than object in the future
+  once(event: "message", listener: (notification: object) => void): this;
+  // TODO: use more specific type than object in the future
+  off(event: "message", listener: (notification: object) => void): this;
 
   /**
    * Emitted when an error is encountered on the WebSocket
    */
   on(event: "error", listener: (error: ErrorEvent) => void): this;
+  /**
+   * Emitted when an error is encountered on the WebSocket
+   */
+  once(event: "error", listener: (error: ErrorEvent) => void): this;
+  off(event: "error", listener: (error: ErrorEvent) => void): this;
 }
 
 /**


### PR DESCRIPTION
<!-- When adding a new feature: -->

# New feature description

Adds support for `once` and `off` events in `LiveNotifications`

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
