### PR TITLE
Run sonar scan in separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "npm"
       - run: npm ci
       - run: npm run build
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x' }}
         with:
-          name: code-coverage
+          name: code-coverage-${matrix.os}-${matrix.node-version}
           path: coverage/
 
   sonar-scan:
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/download-artifact@v3
         with:
-          name: code-coverage
+          name: code-coverage-ubuntu-latest-16.x
           path: coverage/
       - uses: SonarSource/sonarcloud-github-action@v1.6
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,31 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
-
+      # Upload coverage for sonarcube
+      - uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage
+          path: coverage/
+    
+  sonar-scan:
+    needs: [unit-tests]
+    runs-on: ${{ matrix.os }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    strategy:
+      matrix:
+        # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
+        os: [ubuntu-latest]
+        node-version: [16.x]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: code-coverage
+          path: coverage/
       # Sonar analysis needs the full history for features like automatic assignment of bugs. If the following step
       # is not included the project will show a warning about incomplete information.
       - run: git fetch --unshallow
-        if: ${{ matrix.node-version == '16.x' && matrix.os == 'ubuntu-latest' }}
       # Run Sonar analysis on just the latest ubuntu/node runner.
       - uses: SonarSource/sonarcloud-github-action@v1.6
-        if: ${{ matrix.node-version == '16.x' && matrix.os == 'ubuntu-latest' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,19 +23,15 @@ jobs:
       - run: npm test
       # Upload coverage for sonarcube
       - uses: actions/upload-artifact@v3
+        if: ${{ matrix.os == ubuntu-latest && matrix.node-version == 16.x }}
         with:
           name: code-coverage
           path: coverage/
 
   sonar-scan:
     needs: [unit-tests]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
-    strategy:
-      matrix:
-        # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
-        os: [ubuntu-latest]
-        node-version: [16.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           name: code-coverage
           path: coverage/
-    
+
   sonar-scan:
     needs: [unit-tests]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x' }}
         with:
-          name: code-coverage-${matrix.os}-${matrix.node-version}
+          name: code-coverage-${{matrix.os}}-${{matrix.node-version}}
           path: coverage/
 
   sonar-scan:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node${{ runner.node-version }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
       - run: npm ci
       - run: npm run build
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         os: [ubuntu-latest]
         node-version: [16.x]
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           name: code-coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
-      # Upload coverage for sonarcube
+      # Upload coverage for sonarcube (only matching OS and one node version required)
       - uses: actions/upload-artifact@v3
         if: ${{ matrix.os == ubuntu-latest && matrix.node-version == 16.x }}
         with:
@@ -34,14 +34,14 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Sonar analysis needs the full history for features like automatic assignment of bugs. If the following step
+          # is not included the project will show a warning about incomplete information.
+          fetch-depth: 0
       - uses: actions/download-artifact@v3
         with:
           name: code-coverage
           path: coverage/
-      # Sonar analysis needs the full history for features like automatic assignment of bugs. If the following step
-      # is not included the project will show a warning about incomplete information.
-      - run: git fetch --unshallow
-      # Run Sonar analysis on just the latest ubuntu/node runner.
       - uses: SonarSource/sonarcloud-github-action@v1.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - run: npm test
       # Upload coverage for sonarcube (only matching OS and one node version required)
       - uses: actions/upload-artifact@v3
-        if: ${{ matrix.os == ubuntu-latest && matrix.node-version == 16.x }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x' }}
         with:
           name: code-coverage
           path: coverage/


### PR DESCRIPTION
This allows to run add sonar-specific conditions (e.g. not running the scan with dependabot) at a job level, rather than doing it for each step.

