### PR TITLE
ci: disable running on "ESS PodSpaces" environment due to migration

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -16,7 +16,9 @@ jobs:
       name: ${{ matrix.environment-name }}
     strategy:
       matrix:
-        environment-name: ["ESS PodSpaces", "ESS PodSpaces Next"]
+        # Note: "ESS PodSpaces" has been disabled due to the migration
+        # "ESS PodSpaces Next" is the new 2.0 URLs for production.
+        environment-name: ["ESS PodSpaces Next"]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 16.x

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -19,7 +19,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version: [16.x]
-        environment-name: ["ESS PodSpaces", "ESS PodSpaces Next"]
+        # Note: "ESS PodSpaces" has been disabled due to the migration
+        # "ESS PodSpaces Next" is the new 2.0 URLs for production.
+        environment-name: ["ESS PodSpaces Next"]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
This disables running the e2e tests against the ESS 1.1 URLs (currently known in this repo as ESS PodSpaces — "ESS PodSpaces Next" is the 2.0 URLs which we're using [post-migration](https://inrupt.com/blog/pod-spaces-upgrade).