### PR TITLE
docs: fix typo in README.md and docs related to environments supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Parcel.
 @inrupt/solid-client-notifications is part of a family open source JavaScript
 libraries designed to support developers building Solid applications.
 
-# Supported environment
+# Supported environments
 
 Our JavaScript Client Libraries use relatively modern JavaScript, aligned with
 the [ES2018](https://262.ecma-international.org/9.0/) Specification features, we
@@ -25,27 +25,25 @@ ship both [ESM](https://nodejs.org/docs/latest-v16.x/api/esm.html) and
 [CommonJS](https://nodejs.org/docs/latest-v16.x/api/modules.html), with type
 definitions for TypeScript alongside.
 
-This mean that we only support environments (browsers or runtimes) that were
-released after mid-2018 out of the box, if you wish to target these
+This means that out of the box, we only support environments (browsers or
+runtimes) that were released after mid-2018, if you wish to target other (older)
 environments, then you will need to cross-compile our SDKs via the use of
 [Babel](https://babeljs.io), [webpack](https://webpack.js.org/),
 [SWC](https://swc.rs/), or similar.
-
-Additionally, when using this package in an environment other than Node.js, you
-will need [a polyfill for Node's `buffer`
-module](https://www.npmjs.com/package/buffer).
-
-# Browser support
 
 If you need support for Internet Explorer, it is recommended to pass them
 through a tool like [Babel](https://babeljs.io), and to add polyfills for e.g.
 `Map`, `Set`, `Promise`, `Headers`, `Array.prototype.includes`, `Object.entries`
 and `String.prototype.endsWith`.
 
-# Node support
+Additionally, when using this package in an environment other than Node.js, you
+will need [a polyfill for Node's `buffer`
+module](https://www.npmjs.com/package/buffer).
 
-Our JavaScript Client Libraries track Node.js LTS releases, and support 14.x,
-and 16.x.
+## Node.js Support
+
+Our JavaScript Client Libraries track Node.js [LTS
+releases](https://nodejs.org/en/about/releases/), and support 14.x, and 16.x.
 
 # Installation
 

--- a/docs/api/source/index.rst
+++ b/docs/api/source/index.rst
@@ -52,14 +52,24 @@ See `the release notes
 <https://github.com/inrupt/solid-client-notifications-js/blob/main/CHANGELOG.md>`__.
 
 
-Browser Support
-~~~~~~~~~~~~~~~
+Supported environments
+~~~~~~~~~~~~~~~~~~~~~~
 
-Our JavaScript Client Libraries use relatively modern JavaScript features that
-will work in all commonly-used browsers, except Internet Explorer. If you need
-support for Internet Explorer, it is recommended to pass them through a tool
-like `Babel <https://babeljs.io>`__, and to add polyfills for e.g. ``Map``,
-``Set``, ``Promise``, ``Headers``, ``Array.prototype.includes``,
+Our JavaScript Client Libraries use relatively modern JavaScript, aligned with
+the `ES2018 <https://262.ecma-international.org/9.0/>`__ Specification features, we
+ship both `ESM <https://nodejs.org/docs/latest-v16.x/api/esm.html>`__ and
+`CommonJS <https://nodejs.org/docs/latest-v16.x/api/modules.html>`__, with type
+definitions for TypeScript alongside.
+
+This means that out of the box, we only support environments (browsers or
+runtimes) that were released after mid-2018, if you wish to target other (older)
+environments, then you will need to cross-compile our SDKs via the use of `Babel
+<https://babeljs.io>`__, `webpack <https://webpack.js.org/>`__, `SWC
+<https://swc.rs/>`__, or similar.
+
+If you need support for Internet Explorer, it is recommended to pass them
+through a tool like `Babel <https://babeljs.io>`__, and to add polyfills for
+e.g. ``Map``, ``Set``, ``Promise``, ``Headers``, ``Array.prototype.includes``,
 ``Object.entries`` and ``String.prototype.endsWith``.
 
 Additionally, when using this package in an environment other than Node.js, you
@@ -67,7 +77,7 @@ will need `a polyfill for Node's buffer module
 <https://www.npmjs.com/package/buffer>`__.
 
 Node.js Support
-~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^
 
 Our JavaScript Client Libraries track Node.js `LTS releases
 <https://nodejs.org/en/about/releases/>`__, and support 14.x, and 16.x.

--- a/src/notification.test.ts
+++ b/src/notification.test.ts
@@ -31,7 +31,7 @@ import {
 
 import crossFetch, { Response } from "cross-fetch";
 import type * as SolidClient from "@inrupt/solid-client";
-import type * as SolidClientAuthnBrowser from "@inrupt/solid-client-authn-browser";
+// import type * as SolidClientAuthnBrowser from "@inrupt/solid-client-authn-browser";
 
 import { protocols } from "./interfaces";
 import { BaseNotification } from "./notification";

--- a/src/websocketNotification.test.ts
+++ b/src/websocketNotification.test.ts
@@ -24,8 +24,6 @@
 import { it, describe, expect, jest } from "@jest/globals";
 
 import { MessageEvent, CloseEvent, ErrorEvent } from "isomorphic-ws";
-import { NotificationConnectionInfo } from "./interfaces";
-
 import { WebsocketNotification } from "./websocketNotification";
 
 jest.mock("isomorphic-ws");


### PR DESCRIPTION
This is follow up to #501, branching from #503 