### PR TITLE
Remove unused direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "@types/dotenv-flow": "^3.2.0",
         "@types/jest": "^29.2.3",
         "@types/node": "^20.1.1",
-        "@types/rdfjs__dataset": "^1.0.5",
         "dotenv-flow": "^3.2.0",
         "eslint": "^8.22.0",
         "jest": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@types/dotenv-flow": "^3.2.0",
     "@types/jest": "^29.2.3",
     "@types/node": "^20.1.1",
-    "@types/rdfjs__dataset": "^1.0.5",
     "dotenv-flow": "^3.2.0",
     "eslint": "^8.22.0",
     "jest": "^29.3.1",


### PR DESCRIPTION
It still comes through transitively, but isn't used directly in this codebase.