### PR TITLE
Move solid-client from peer to direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
+        "@inrupt/solid-client": "^2.0.0",
         "events": "^3.3.0",
         "isomorphic-ws": "^5.0.0",
         "ws": "^8.12.0"
@@ -46,9 +47,6 @@
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
-      },
-      "peerDependencies": {
-        "@inrupt/solid-client": "^2.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -90,12 +90,10 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@inrupt/solid-client": "^2.0.0",
     "events": "^3.3.0",
     "isomorphic-ws": "^5.0.0",
     "ws": "^8.12.0"
-  },
-  "peerDependencies": {
-    "@inrupt/solid-client": "^2.0.0"
   },
   "engines": {
     "node": "^18.0.0 || ^20.0.0"


### PR DESCRIPTION
Nothing from `@inrupt/solid-client` is part of the public API of `@inrupt/solid-client-notifications`, so there isn't any reason for it to be a peer dependency over a direct one.