### PR TITLE
Integrate problem details library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^2.0.0",
+        "@inrupt/solid-client-errors": "^0.0.1",
         "events": "^3.3.0",
         "isomorphic-ws": "^5.0.0",
         "ws": "^8.12.0"
@@ -1020,6 +1021,14 @@
       ],
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@inrupt/solid-client-errors": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-errors/-/solid-client-errors-0.0.1.tgz",
+      "integrity": "sha512-7OgjR6pdNVZEVZptL/2EzOWOArjFARg60ogiH/pFUkWSaiyx5bU//WG+pjlBlxiGJSXdxHOZ0lvH6zGv/p7rmQ==",
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   },
   "dependencies": {
     "@inrupt/solid-client": "^2.0.0",
+    "@inrupt/solid-client-errors": "^0.0.1",
     "events": "^3.3.0",
     "isomorphic-ws": "^5.0.0",
     "ws": "^8.12.0"

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -19,6 +19,9 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+/**
+ * @deprecated This error class should not be used.
+ */
 export class FetchError extends Error {
   response: Response;
 

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -20,8 +20,9 @@
 //
 
 import { getIri, getThingAll, getWellKnownSolid } from "@inrupt/solid-client";
+import { handleErrorResponse } from "@inrupt/solid-client-errors";
 
-import { FetchError, NotSupported } from "./errors";
+import { NotSupported } from "./errors";
 import type {
   protocols,
   FeatureOptions,
@@ -132,13 +133,8 @@ export class BaseNotification {
     });
 
     if (response.status !== 200) {
-      throw new FetchError(
-        response.url,
-        response.status,
-        response.statusText,
-        "protocol negotiation info",
-        response,
-      );
+      const responseBody = await response.text();
+      throw handleErrorResponse(response, responseBody, "protocol negotiation info");
     }
 
     return response.json();
@@ -160,13 +156,8 @@ export class BaseNotification {
     });
 
     if (response.status !== 200) {
-      throw new FetchError(
-        response.url,
-        response.status,
-        response.statusText,
-        "connection info",
-        response,
-      );
+      const responseBody = await response.text();
+      throw handleErrorResponse(response, responseBody, "connection info");
     }
 
     return response.json();


### PR DESCRIPTION
This is an initial integration with the `@inrupt/solid-client-errors` library.

There are currently three error types used in the notification library:

* `FetchError`
* `NotImplementedError`
* `NotSupportedError`

The second two do not contain information relevant to Problem Details: they are not changed. The first one handles HTTP errors where problem details responses are relevant. Rather than adapting the `FetchError` to inherit from a problem details-supported class, this PR deprecates the `FetchError` class and replaces the usages of that class with a problem details processor.

In the first commit, there are no changes to the test code. If this PR seems to be going in the right direction, I will add tests to cover these changes.