### PR TITLE
SDK-3368: Feature flag problem details tests

### DIFF
--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -19,6 +19,10 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+// Assertions are made conditionally on problem details responses because not all
+// servers support this feature.
+/* eslint-disable jest/no-conditional-expect */
+
 import {
   describe,
   it,
@@ -179,7 +183,9 @@ describe(`Authenticated end-to-end notifications tests for environment [${env.en
     expect(problemDetails.type).toBe(DEFAULT_TYPE);
     expect(problemDetails.title).toBe("Method Not Allowed");
     expect(problemDetails.status).toBe(405);
-    expect(problemDetails.detail).toBeDefined();
-    expect(problemDetails.instance).toBeDefined();
+    if (env?.features?.PROBLEM_DETAILS === "true") {
+      expect(problemDetails.detail).toBeDefined();
+      expect(problemDetails.instance).toBeDefined();
+    }
   });
 });


### PR DESCRIPTION
The end-to-end tests need to run against older supported versions of ESS, not all of which support problem details.

By default, only the response status and title are checked, which are provided by default against any HTTP response. Problem details and instance are only checked if the environment variable E2E_TEST_FEATURE_PROBLEM_DETAILS is set to true.