### PR TITLE
Exclude test app transitive optional dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:unit:node": "jest --selectProjects node",
     "test:e2e:node": "jest --selectProjects e2e-node --testTimeout 15000 --collectCoverage false",
     "test:e2e:browser": "playwright test",
-    "test:e2e:browser:setup": "cd e2e/browser/test-app && npm ci",
+    "test:e2e:browser:setup": "cd e2e/browser/test-app && npm ci --omit=optional",
     "licenses:list": "npx license-checker --production --csv --out LICENSE_DEPENDENCIES_ALL",
     "licenses:check": "npx license-checker --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
     "prepublishOnly": "npm run build"


### PR DESCRIPTION
NextJS 15 brings in an optional dependency with a license incompatible with our policy, so this exclude optional dependencies when installing the test app.