### PR TITLE
Setup staged publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,5 @@ jobs:
       # Ensure npm 11.5.1 or later for trusted publishing
       - run: npm install -g npm@latest
       - run: npm ci
-      - run: npm publish
+      - run: npm stage publish
+      - run: echo "The package has been staged, go to https://www.npmjs.com to publish it."

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -19,8 +19,13 @@
 //
 
 import type { Config } from "jest";
+import { createRequire } from "node:module";
 
 type ArrayElement<MyArray> = MyArray extends Array<infer T> ? T : never;
+
+// Jest 30 loads .ts config files as ESM via Node's native TypeScript support,
+// so `require` is not available. Use createRequire for require.resolve calls.
+const esmRequire = createRequire(import.meta.url);
 
 const baseConfig: ArrayElement<NonNullable<Config["projects"]>> = {
   preset: "ts-jest",
@@ -29,6 +34,11 @@ const baseConfig: ArrayElement<NonNullable<Config["projects"]>> = {
   clearMocks: true,
   injectGlobals: false,
   modulePathIgnorePatterns: ["node_modules/"],
+  transformIgnorePatterns: ["node_modules[\\\\/](?!jose|uuid)"],
+  moduleNameMapper: {
+    "^jose": esmRequire.resolve("jose"),
+    "^uuid": esmRequire.resolve("uuid"),
+  },
 };
 
 export default {


### PR DESCRIPTION
Enforces an operator intervention (gated by 2FA) to publish the package after the automated CI staged it.

This mirrors the change made in `solid-client-errors-js` (inrupt/solid-client-errors-js#619): the release workflow now runs `npm stage publish` instead of `npm publish`, so a human must complete publication on npmjs.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)