### PR TITLE
Disable E2E tests on deprecated environments

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -15,7 +15,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        environment-name: ["ESS Release-2-3", "ESS Next"]
+        environment-name: ["ESS PodSpaces"]
         experimental: [false]
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version: ["22.x", "24.x"]
-        environment-name: ["ESS Release-2-3", "ESS Next"]
+        environment-name: ["ESS PodSpaces"]
         experimental: [false]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Disables E2E tests on deprecated ESS environments (ESS Release-2-3, ESS Next), keeping only ESS PodSpaces.

Mirrors the change made in `solid-client-vc-js` (branch `SDK-3453/disable-dev-next-tests`).

Note: this repo's matrix previously listed only `["ESS Release-2-3", "ESS Next"]` (no `ESS PodSpaces`). Since removing the deprecated environments would have left an empty matrix, the matrix is set to `["ESS PodSpaces"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)